### PR TITLE
feat(build): add support for custom development port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
   <p>A fast Deno-powered static site generator.</p>
   <small>Sponsored by <a href="https://tuta.com">Tuta</a></small>
 <br><br>
-  
-  [![JSR](https://jsr.io/badges/@steno/steno)](https://jsr.io/@steno/steno)
+
+[![JSR](https://jsr.io/badges/@steno/steno)](https://jsr.io/@steno/steno)
 [![JSR Score](https://jsr.io/badges/@steno/steno/score)](https://jsr.io/@steno/steno)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/stenopress/steno/ci.yml)
 
@@ -41,7 +41,8 @@ and theme-driven static websites.
 - Theme layouts, components, and static assets
 - Scribe templates for layouts and components
 - Incremental page rebuilds with layered in-memory + on-disk cache
-- Live-reloading dev server on `http://localhost:8000`
+- Live-reloading dev server on `http://localhost:5735` (auto-falls back to the
+  next free port)
 - CLI support for `build`, `dev`, `--config`, and `--help`
 - Root test harness with `deno task test`
 
@@ -176,6 +177,7 @@ Supported top-level fields used by the current runtime include:
 - `contentDir`
 - `output`
 - `custom.shortUrls`
+- `custom.devPort`
 - `custom.theme`
 - `custom.themeConfig`
 - `custom.globals`
@@ -194,6 +196,7 @@ head:
     content: /favicon.ico
 
 custom:
+  devPort: 5735
   shortUrls: true
   theme: "./test/test-theme"
   themeConfig:

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -73,6 +73,7 @@ interface SiteConfig {
   contentDir?: string; // Default: "content"
   output?: string; // Default: "dist"
   custom?: {
+    devPort?: number; // Preferred dev-server port (default: 5735, auto-increments if used)
     theme?: string; // Path or URL to theme
     themeConfig?: Record<string, unknown>; // Theme-specific config
     globals?: Record<string, unknown>; // Global template variables

--- a/docs/config_reference.md
+++ b/docs/config_reference.md
@@ -116,6 +116,16 @@ plugins.
     shortUrls: true
   ```
 
+- **`custom.devPort`** (number, optional): Preferred starting port for
+  `steno dev`.
+  - **Default**: `5735`
+  - If this port is busy, Steno automatically tries the next ports (`5736`,
+    `5737`, ...) until it finds one that is free.
+  ```yaml
+  custom:
+    devPort: 5735
+  ```
+
 - **`custom.pluginSecurity`** (object, optional): Security policy for plugin
   module imports.
   - **Secure defaults**:
@@ -145,6 +155,7 @@ contentDir: "content"
 output: "dist"
 
 custom:
+  devPort: 5735
   theme: "./theme"
   themeConfig:
     brand: "Steno"

--- a/packages/init/src/onboarding.ts
+++ b/packages/init/src/onboarding.ts
@@ -384,7 +384,7 @@ Your Steno site is ready. Edit this page at \`content/index.md\`.
       `{
   "tasks": {
     "build": "deno run --allow-read=content,content/.steno --allow-write=dist,content/.steno jsr:@steno/steno build",
-    "dev": "deno run --allow-read=content,content/.steno,dist --allow-write=dist,content/.steno --allow-net=127.0.0.1:8000 jsr:@steno/steno dev"
+    "dev": "deno run --allow-read=content,content/.steno,dist --allow-write=dist,content/.steno --allow-net=127.0.0.1,0.0.0.0 jsr:@steno/steno dev"
   },
   "imports": {
     "@steno/steno": "jsr:@steno/steno"

--- a/src/core/steno.ts
+++ b/src/core/steno.ts
@@ -1,7 +1,7 @@
 import { Theme } from "../theme/theme.ts";
 import type { SiteConfig, StenoHooks, StenoPlugin } from "../types.ts";
 import { isStenoPlugin } from "../plugins/plugins.ts";
-import { startDevServer } from "../utils/server.ts";
+import { DEFAULT_DEV_PORT, startDevServer } from "../utils/server.ts";
 import { loadPlugins } from "./config.ts";
 import { buildSite, type BuildState } from "./steno_build.ts";
 import { loadTheme } from "./steno_theme.ts";
@@ -88,11 +88,13 @@ export class Steno {
     const project = await this.projectPromise;
     const contentDir = project.config.contentDir || "content";
     const outputDir = project.config.output || "dist";
+    const devPort = project.config.custom?.devPort ?? DEFAULT_DEV_PORT;
     await startDevServer(
       outputDir,
       () => this.devBuild(),
       [contentDir, getDataDir(contentDir)],
       [join(contentDir, ".steno"), outputDir],
+      devPort,
     );
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export interface SiteConfig {
   custom?: {
     stylesheets?: string[];
     shortUrls?: boolean;
+    devPort?: number;
     theme?: string;
     themeConfig?: Record<string, unknown>;
     globals?: Record<string, unknown>;

--- a/src/utils/server.ts
+++ b/src/utils/server.ts
@@ -1,6 +1,8 @@
 import { join } from "@std/path";
 import { isPathInsideOrEqual } from "../core/path_utils.ts";
 
+export const DEFAULT_DEV_PORT = 5735;
+
 const reloadScript = `
   <script>
     if (typeof(EventSource) !== "undefined") {
@@ -15,6 +17,58 @@ const reloadScript = `
 `;
 
 const textEncoder = new TextEncoder();
+const MAX_PORT = 65535;
+
+type PortAvailabilityCheck = (port: number) => Promise<boolean>;
+
+async function isPortAvailable(
+  port: number,
+  hostname: string,
+): Promise<boolean> {
+  let listener: Deno.Listener | undefined;
+  try {
+    listener = Deno.listen({ hostname, port });
+    return true;
+  } catch (error) {
+    if (error instanceof Deno.errors.AddrInUse) {
+      return false;
+    }
+    throw error;
+  } finally {
+    listener?.close();
+  }
+}
+
+/** Finds the first available TCP port starting at the requested port. */
+export async function findAvailablePort(
+  startPort: number,
+  options: {
+    hostname?: string;
+    maxPort?: number;
+    isPortAvailable?: PortAvailabilityCheck;
+  } = {},
+): Promise<number> {
+  if (!Number.isInteger(startPort) || startPort < 1 || startPort > MAX_PORT) {
+    throw new Error(
+      `Invalid start port "${startPort}". Expected an integer between 1 and ${MAX_PORT}.`,
+    );
+  }
+
+  const hostname = options.hostname ?? "0.0.0.0";
+  const maxPort = options.maxPort ?? MAX_PORT;
+  const portCheck = options.isPortAvailable ??
+    ((port: number) => isPortAvailable(port, hostname));
+
+  for (let port = startPort; port <= maxPort; port++) {
+    if (await portCheck(port)) {
+      return port;
+    }
+  }
+
+  throw new Error(
+    `No available port found in range ${startPort}-${maxPort}.`,
+  );
+}
 
 /** Internal state for connected reload clients. */
 interface DevServerState {
@@ -93,6 +147,7 @@ export async function startDevServer(
   buildFn: () => void | Promise<void>,
   watchDirs: string | string[] = "content",
   ignoredPaths: string[] = [],
+  preferredPort: number = DEFAULT_DEV_PORT,
 ): Promise<void> {
   const { handler, broadcastReload } = createDevServerHandler(outputDir);
 
@@ -100,17 +155,24 @@ export async function startDevServer(
 
   const dirsToWatch = Array.isArray(watchDirs) ? watchDirs : [watchDirs];
   const watcher = Deno.watchFs(dirsToWatch);
+  const port = await findAvailablePort(preferredPort);
 
-  Deno.serve({ port: 8000, handler });
+  Deno.serve({ port, handler });
+
+  if (port !== preferredPort) {
+    console.warn(
+      `  \x1b[33mport ${preferredPort} is in use, switched to ${port}\x1b[0m`,
+    );
+  }
 
   console.log("");
   console.log("  \x1b[32msteno\x1b[0m  \x1b[90mdev server\x1b[0m");
   console.log("");
   console.log(
-    "  \x1b[90m➜\x1b[0m  \x1b[1mLocal\x1b[0m:   \x1b[36mhttp://localhost:8000/\x1b[0m",
+    `  \x1b[90m➜\x1b[0m  \x1b[1mLocal\x1b[0m:   \x1b[36mhttp://localhost:${port}/\x1b[0m`,
   );
   console.log(
-    "  \x1b[90m➜\x1b[0m  \x1b[1mNetwork\x1b[0m: \x1b[36mhttp://0.0.0.0:8000/\x1b[0m",
+    `  \x1b[90m➜\x1b[0m  \x1b[1mNetwork\x1b[0m: \x1b[36mhttp://0.0.0.0:${port}/\x1b[0m`,
   );
   console.log("");
 

--- a/src/utils/server_test.ts
+++ b/src/utils/server_test.ts
@@ -1,6 +1,10 @@
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
-import { createDevServerHandler, injectReloadScript } from "./server.ts";
+import {
+  createDevServerHandler,
+  findAvailablePort,
+  injectReloadScript,
+} from "./server.ts";
 
 export function registerServerTests(): void {
   Deno.test("server: injectReloadScript adds the reload script before body close", () => {
@@ -28,7 +32,7 @@ export function registerServerTests(): void {
       const { handler } = createDevServerHandler(tempDir);
 
       const htmlResponse = await handler(
-        new Request("http://localhost:8000/"),
+        new Request("http://localhost:5735/"),
       );
       assertEquals(htmlResponse.status, 200);
       assertEquals(
@@ -41,14 +45,14 @@ export function registerServerTests(): void {
       );
 
       const cssResponse = await handler(
-        new Request("http://localhost:8000/style.css"),
+        new Request("http://localhost:5735/style.css"),
       );
       assertEquals(cssResponse.status, 200);
       assertEquals(cssResponse.headers.get("Content-Type"), "text/css");
       assertEquals(await cssResponse.text(), "body { color: red; }");
 
       const reloadResponse = await handler(
-        new Request("http://localhost:8000/reload"),
+        new Request("http://localhost:5735/reload"),
       );
       assertEquals(reloadResponse.status, 200);
       assertEquals(
@@ -56,5 +60,27 @@ export function registerServerTests(): void {
         "text/event-stream",
       );
     },
+  });
+
+  Deno.test("server: findAvailablePort returns first free port", async () => {
+    const port = await findAvailablePort(5735, {
+      maxPort: 5737,
+      isPortAvailable: (candidatePort) =>
+        Promise.resolve(candidatePort === 5737),
+    });
+
+    assertEquals(port, 5737);
+  });
+
+  Deno.test("server: findAvailablePort throws when range is exhausted", async () => {
+    await assertRejects(
+      () =>
+        findAvailablePort(5735, {
+          maxPort: 5736,
+          isPortAvailable: () => Promise.resolve(false),
+        }),
+      Error,
+      "No available port found in range 5735-5736.",
+    );
   });
 }


### PR DESCRIPTION
while updating the deafult devport to 5735, and adding a system if this port is busy, Steno automatically tries the next ports

---

closes #65 