### PR TITLE
feat(tau)!: add Tau 0.9 language features 

### DIFF
--- a/benchmarks/pipeline.bench.ts
+++ b/benchmarks/pipeline.bench.ts
@@ -47,11 +47,11 @@ const components = {
   Footer: "<footer>{#each tags as tag}<span>{tag}</span>{/each}</footer>",
 };
 
-function runPagePipeline(markdown: string): string {
+async function runPagePipeline(markdown: string): Promise<string> {
   const { frontmatter, body } = parseFrontmatter(markdown);
   const bodyHtml = marked.parse(body);
 
-  return render({
+  return await render({
     template: layoutTemplate,
     context: {
       site: { title: "Steno" },
@@ -65,13 +65,13 @@ function runPagePipeline(markdown: string): string {
 Deno.bench(
   "pipeline (typical page parse->markdown->tau)",
   { group: "pipeline", baseline: true },
-  () => {
-    runPagePipeline(pageTemplate);
+  async () => {
+    await runPagePipeline(pageTemplate);
   },
 );
 
 Deno.bench("pipeline (large page parse->markdown->tau)", {
   group: "pipeline",
-}, () => {
-  runPagePipeline(largePageTemplate);
+}, async () => {
+  await runPagePipeline(largePageTemplate);
 });

--- a/benchmarks/tau.bench.ts
+++ b/benchmarks/tau.bench.ts
@@ -109,8 +109,8 @@ const unclosedTemplate = `
 Deno.bench(
   "tau render (simple)",
   { group: "tau", baseline: true },
-  () => {
-    render({
+  async () => {
+    await render({
       template: simpleTemplate,
       context: simpleContext,
       components: {},
@@ -118,8 +118,8 @@ Deno.bench(
   },
 );
 
-Deno.bench("tau render (components + loops)", { group: "tau" }, () => {
-  render({
+Deno.bench("tau render (components + loops)", { group: "tau" }, async () => {
+  await render({
     template: layoutTemplate,
     context: complexContext,
     components,
@@ -129,8 +129,8 @@ Deno.bench("tau render (components + loops)", { group: "tau" }, () => {
 Deno.bench(
   "tau render (list of 1000 items)",
   { group: "tau-scale", baseline: true },
-  () => {
-    render({
+  async () => {
+    await render({
       template: largeListTemplate,
       context: { items: thousandItems },
       components: {
@@ -144,8 +144,8 @@ Deno.bench(
 Deno.bench(
   "tau render (4-level nested loops)",
   { group: "tau-scale" },
-  () => {
-    render({
+  async () => {
+    await render({
       template: nestedTemplate,
       context: { sections: deepTree },
       components: deepComponents,
@@ -156,9 +156,9 @@ Deno.bench(
 Deno.bench(
   "tau render (unclosed tag fails fast)",
   { group: "tau-errors", baseline: true },
-  () => {
+  async () => {
     try {
-      render({
+      await render({
         template: unclosedTemplate,
         context: {},
         components: {},

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -25,19 +25,22 @@ description, date) generated from the current page set, see
 
 `new Theme(themeData, userConfig?)` creates a theme. `Theme.loadFromDirectory`
 loads a convention-based local theme. `renderLayout(name, content, variables)`
-and `renderComponent(name, variables)` render templates; `copyAssets(outputDir)`
-writes its assets.
+and `renderComponent(name, variables)` render templates and return
+`Promise<string>`; `copyAssets(outputDir)` writes its assets.
 
 ## Tau
 
 `render({ template, context, components, filePath?, includeResolver?, limits? })`
-renders a template. `components` is required (use `{}` when none).
-`includeResolver` is a caller-supplied `(path: string) => string` function that
-resolves `{@include "path"}` directives to template source; it is required only
-when a template uses `{@include}`, and API consumers rendering templates
-directly (outside a theme) provide their own. `filters` is the mutable
-null-prototype map of built-in filter functions, enabling applications to add
-filters before rendering.
+renders a template and returns `Promise<string>`. It is async because a template
+expression may call a context-supplied function that returns a promise
+(`{someAsyncFn()}`); the result is awaited implicitly, so a sync function works
+the same way. Filters may also return a promise. `components` is required (use
+`{}` when none). `includeResolver` is a caller-supplied
+`(path: string) => string` function that resolves `{@include "path"}` directives
+to template source; it is required only when a template uses `{@include}`, and
+API consumers rendering templates directly (outside a theme) provide their own.
+`filters` is the mutable null-prototype map of built-in filter functions,
+enabling applications to add filters before rendering.
 
 Tau failures use `TauError`; its `code` property is a stable `TauErrorCode`, one
 of `TAU_COMPONENT_CYCLE`, `TAU_COMPONENT_NOT_FOUND`, `TAU_INCLUDE_CYCLE`,

--- a/docs/tau_syntax.md
+++ b/docs/tau_syntax.md
@@ -1,27 +1,36 @@
 # Tau language specification
 
-This document specifies Tau 0.8. Tau templates are UTF-8 text and use the `.tau`
-extension.
+This document specifies Tau 0.9. Tau templates are UTF-8 text and use the `.tau`
+extension. Tau 0.9 is a superset of Tau 0.8: every Tau 0.8 template still parses
+and renders identically (see [Compatibility](#compatibility)).
 
 ## Grammar
 
 The grammar uses an EBNF-like notation. `expression` is the restricted
-JavaScript-expression subset described below.
+JavaScript-expression subset described below. `-` markers on a tag are the
+optional [whitespace-control](#whitespace-control) suffix/prefix.
 
 ```ebnf
-template        = { text | interpolation | raw_html | include
-                  | if_block | each_block | component } ;
+template        = { text | interpolation | raw_html | include | comment
+                  | if_block | each_block | let_binding | component
+                  | children_slot } ;
 interpolation   = "{", expression, { "|", filter }, "}" ;
 filter          = identifier, [ "(", [ expression, { ",", expression } ], ")" ] ;
 raw_html        = "{@html ", expression, "}" ;
 include         = "{@include ", quoted_path, "}" ;
-if_block        = "{#if ", expression, "}", template,
-                  { "{:else if ", expression, "}", template },
-                  [ "{:else}", template ], "{/if}" ;
-each_block      = "{#each ", expression, " as ", identifier,
-                  [ ",", identifier ], "}", template, "{/each}" ;
-component       = "<", upper_identifier, { whitespace, prop },
-                  [ whitespace ], "/>" ;
+comment         = "{#", { any character except "#}" }, "#}" ;
+if_block        = "{", ["-"], "#if ", expression, ["-"], "}", template,
+                  { "{", ["-"], ":else if ", expression, ["-"], "}", template },
+                  [ "{", ["-"], ":else", ["-"], "}", template ],
+                  "{", ["-"], "/if", ["-"], "}" ;
+each_block      = "{", ["-"], "#each ", expression, " as ", identifier,
+                  [ ",", identifier ], ["-"], "}", template,
+                  [ "{", ["-"], ":else", ["-"], "}", template ],
+                  "{", ["-"], "/each", ["-"], "}" ;
+let_binding     = "{#let ", identifier, " = ", expression, "}" ;
+children_slot   = "{@children}" ;
+component       = "<", upper_identifier, { whitespace, prop }, [ whitespace ],
+                  ( "/>" | ">", template, "</", upper_identifier, ">" ) ;
 prop            = identifier
                 | identifier, "=", quoted_string
                 | identifier, "={", expression, "}"
@@ -31,14 +40,26 @@ identifier      = ( letter | "_" | "$" ), { letter | digit | "_" | "$" } ;
 upper_identifier = uppercase_letter, { letter | digit | "_" | "$" } ;
 ```
 
-Control tags must be balanced. Components are self-closing. Includes use a
-literal path; dynamic include paths are not part of Tau 0.8.
+Control tags must be balanced. Components are self-closing (`<Foo />`) or carry
+children (`<Foo>...</Foo>`). Includes use a literal path; dynamic include paths
+are not part of Tau.
+
+## Comments
+
+`{# any text #}` is removed at parse time and produces no output. Comments
+cannot be nested and cannot contain the literal `#}`. A comment does not start
+with `{#if`, `{#each`, or `{#let`, so those tags are never mistaken for one.
+
+```tau
+{# TODO: replace with real navigation once the API ships #}
+```
 
 ## Expressions
 
 Tau accepts side-effect-free JavaScript expressions for property access,
-indexing, comparisons, arithmetic, boolean logic, optional chaining, literals,
-and calls to functions explicitly supplied in the render context.
+indexing, comparisons, arithmetic, boolean logic, the ternary operator, optional
+chaining, nullish coalescing, literals, and calls to functions explicitly
+supplied in the render context.
 
 Tau rejects assignment, increment/decrement, arrow and function expressions,
 classes, `new`, `await`, `yield`, `delete`, template literals, and statement
@@ -46,10 +67,117 @@ separators. It also rejects any identifier in a fixed blocklist, regardless of
 whether it resolves to anything in context: `AsyncFunction`, `Deno`, `Function`,
 `WebAssembly`, `__proto__`, `__tauIterable`, `constructor`, `context`, `eval`,
 `globalThis`, `helpers`, `html`, `import`, `module`, `process`, `prototype`,
-`require`, `self`, and `window`.
+`require`, `self`, and `window`. The blocklist is enforced structurally against
+a parsed expression, not scanned as text: it applies equally to a static
+property (`value.constructor`) and a dynamically computed one
+(`value["constructor"]`, `value["cons" + "tructor"]`), so building a blocked
+name at runtime does not bypass it. A `{#each}` item or index binding, or a
+`{#let}` name, may still shadow a blocklisted name for the duration of its
+scope, the same way a real `for...of` or `const` binding would.
 
 Tau hardening is defense in depth for trusted theme templates. The expression
 subset is not an isolation boundary for arbitrary hostile code.
+
+### Async function calls
+
+A call in an expression (`{fn()}`, `{obj.method(arg)}`) is always awaited, so a
+context-supplied function may be sync or async without any special syntax —
+`await` itself remains rejected as expression syntax. Filters registered on the
+`filters` export may also return a promise; it is awaited the same way.
+`render()` is therefore always `async` and returns `Promise<string>`.
+
+```ts
+render({
+  template: "{fetchTitle()}",
+  context: { fetchTitle: () => fetch("/title").then((r) => r.text()) },
+  components: {},
+});
+```
+
+## Local bindings
+
+`{#let name = expression}` computes `expression` once and binds it to `name` for
+the rest of the enclosing block — the same each/if/component nesting a `{#each}`
+item variable would use. It does not need a closing tag; `name` stops being
+visible at the end of the block it appears in (end of the template, or the
+enclosing `{#if}`/`{#each}`/component-children block).
+
+```tau
+{#each posts as post}
+  {#let excerpt = post.body | truncate(120)}
+  <p>{excerpt}</p>
+{/each}
+```
+
+`name` follows the same identifier rules as a component or filter name and
+cannot start with `__tau`.
+
+## Control flow
+
+`{#each items as item}...{:else}...{/each}` renders the `{:else}` branch when
+`items` is nullish, non-iterable, or empty — the loop body never ran. This
+mirrors `{#if}`'s `{:else}` but keys off iteration count instead of a boolean.
+
+```tau
+{#each comments as comment}
+  <li>{comment.body}</li>
+{:else}
+  <li class="empty">No comments yet.</li>
+{/each}
+```
+
+## Components
+
+A component tag is either self-closing (`<Card title={title} />`) or carries
+children (`<Card title={title}>{@html body}</Card>`). Children are compiled in
+the _caller's_ scope — they can reference the surrounding `{#each}` item,
+`{#let}` bindings, and page context — and rendered once, before the component
+template runs. The component template retrieves the rendered children with
+`{@children}`, a zero-argument tag equivalent to `{@html children}`:
+
+```tau
+<!-- theme component: Card.tau -->
+<div class="card"><h2>{title}</h2><div class="body">{@children}</div></div>
+```
+
+```tau
+<!-- usage -->
+<Card title={post.title}>
+  <p>{post.excerpt}</p>
+</Card>
+```
+
+A component with no `{@children}` in its template silently ignores any children
+content passed to it. There is only one, unnamed slot per component; Tau 0.9
+does not have named slots.
+
+## Whitespace control
+
+`{#if}`, `{:else if}`, `{:else}`, `{/if}`, `{#each}`, and `{/each}` accept an
+optional `-` immediately inside the tag delimiter on either side:
+
+- `{-#if cond}` (dash after `{`) trims trailing whitespace from the text
+  immediately _before_ the tag.
+- `{#if cond-}` (dash before `}`) trims leading whitespace from the text
+  immediately _after_ the tag (i.e., at the start of its block).
+- Both can be combined (`{-#if cond-}`), and each closing/branch tag
+  (`{:else-}`, `{-/each}`, `{/if-}`, ...) accepts the same markers
+  independently.
+
+Trimming removes all adjacent whitespace (spaces, tabs, newlines), not just up
+to the next newline. Other tags (`{expr}`, `{@html}`, `{@include}`, component
+tags) do not support trim markers.
+
+```tau
+<ul>
+  {#each items as item-}
+    <li>{item}</li>
+  {-/each}
+</ul>
+```
+
+renders as `<ul>\n  <li>a</li><li>b</li>\n</ul>` instead of leaving a blank line
+per iteration.
 
 ## Values
 
@@ -57,7 +185,8 @@ subset is not an isolation boundary for arbitrary hostile code.
 - `null` and `undefined` interpolate as an empty string.
 - Other interpolated values are converted with `String(value)`.
 - Missing values are false in conditions.
-- A nullish or non-iterable value produces zero loop iterations.
+- A nullish or non-iterable value produces zero loop iterations (and runs
+  `{:else}` if present).
 - Invalid property access or a context function that throws produces
   `TAU_RENDER_FAILED` with the original failure available as `cause`.
 - Component boolean props have the value `true`.
@@ -77,7 +206,8 @@ subset is not an isolation boundary for arbitrary hostile code.
 - `url` validates a value for use in a URL attribute; see below.
 
 Filters chain left to right: `{value | truncate(20) | upper}` truncates first,
-then uppercases the result.
+then uppercases the result. A filter may be sync or async (see
+[Async function calls](#async-function-calls)).
 
 ## Escaping and output contexts
 
@@ -98,7 +228,10 @@ schemes. It is a validation step; normal interpolation then HTML-escapes the
 result.
 
 `{@html expression}` performs no escaping and is only for trusted,
-already-sanitized HTML. Tau does not provide an HTML sanitizer.
+already-sanitized HTML. Tau does not provide an HTML sanitizer. `{@children}` is
+sugar for `{@html children}` and carries the same caveat: children content is
+inserted unescaped, since it was already rendered (and escaped where
+appropriate) at the call site.
 
 Component prop expressions pass values without stringification to the component
 context. Escaping occurs when the component interpolates those values.
@@ -125,4 +258,7 @@ patch releases. Source-backed parse errors also expose `filePath`, `line`, and
 
 Tau follows Steno's compatibility policy. The executable fixtures under
 `src/utils/fixtures/tau/` record output and error-code behavior for each
-released Tau language line.
+released Tau language line. Tau 0.9 is purely additive over 0.8 — every
+construct in `v0.8.json` still produces the same output or error code; new
+behavior (comments, `{#let}`, each/`{:else}`, component children, whitespace
+control, async calls) is covered separately in `v0.9.json`.

--- a/src/core/build/build.ts
+++ b/src/core/build/build.ts
@@ -370,7 +370,7 @@ export async function buildSite({
         };
 
         const layoutContent = theme
-          ? theme.renderLayout(layoutName, htmlContent, pageContext)
+          ? await theme.renderLayout(layoutName, htmlContent, pageContext)
           : htmlContent;
         const renderedContent = injectHeadTags(layoutContent, pageHead);
 

--- a/src/core/project_test.ts
+++ b/src/core/project_test.ts
@@ -19,7 +19,7 @@ export function registerProjectTests(): void {
       assertEquals(theme?.name, "marketing-minimal");
       if (!theme) throw new Error("Marketing theme failed to load.");
       assertEquals(theme?.config.primaryLabel, "Get started");
-      const html = theme?.renderLayout("layout", "<h2>Details</h2>", {
+      const html = await theme?.renderLayout("layout", "<h2>Details</h2>", {
         title: "Launch",
         site: { title: "Launch", navigation: [] },
         theme: { name: theme.name, version: theme.version, ...theme.config },

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -407,12 +407,12 @@ export class Theme {
   /**
    * Internal common renderer wrapper to dry up Tau orchestrations.
    */
-  private executeRender(
+  private async executeRender(
     template: string,
     context: Record<string, unknown>,
     filePath?: string,
-  ): string {
-    return render({
+  ): Promise<string> {
+    return await render({
       template,
       context,
       components: this.themeData.components || {},
@@ -428,11 +428,11 @@ export class Theme {
   /**
    * Renders a layout template with content and page variables using Tau.
    */
-  public renderLayout(
+  public async renderLayout(
     layoutName: string,
     content: string,
     variables: Record<string, unknown>,
-  ): string {
+  ): Promise<string> {
     const template = this.themeData.layouts[layoutName];
     if (!template) {
       throw new Error(
@@ -441,7 +441,7 @@ export class Theme {
         }`,
       );
     }
-    return this.executeRender(
+    return await this.executeRender(
       template,
       { content, ...variables },
       this.layoutPaths[layoutName],
@@ -451,17 +451,17 @@ export class Theme {
   /**
    * Renders a theme component using Tau.
    */
-  public renderComponent(
+  public async renderComponent(
     componentName: string,
     variables: Record<string, unknown>,
-  ): string {
+  ): Promise<string> {
     const template = this.themeData.components?.[componentName];
     if (!template) {
       throw new Error(
         `Component "${componentName}" not found in theme "${this.name}".`,
       );
     }
-    return this.executeRender(
+    return await this.executeRender(
       template,
       variables,
       this.componentPaths[componentName],

--- a/src/theme/theme_test.ts
+++ b/src/theme/theme_test.ts
@@ -1,4 +1,9 @@
-import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
 import { join } from "@std/path";
 import { Theme } from "./theme.ts";
 
@@ -18,7 +23,7 @@ export function registerThemeTests(): void {
     assertEquals(theme.config.author, "site");
   });
 
-  Deno.test("theme: renderLayout receives page/site/theme context", () => {
+  Deno.test("theme: renderLayout receives page/site/theme context", async () => {
     const theme = new Theme({
       name: "minimal",
       version: "1.0.0",
@@ -31,7 +36,7 @@ export function registerThemeTests(): void {
       defaultConfig: { author: "theme-author" },
     });
 
-    const out = theme.renderLayout("layout", "<p>Body</p>", {
+    const out = await theme.renderLayout("layout", "<p>Body</p>", {
       title: "Post",
       site: { title: "Site" },
       theme: { author: "theme-author" },
@@ -97,13 +102,13 @@ export function registerThemeTests(): void {
       Deno.writeTextFileSync(join(themeDir, "assets", "style.css"), `body {}`);
 
       const theme = Theme.loadFromDirectory(themeDir, { author: "override" });
-      const rendered = theme.renderLayout("layout", "<p>x</p>", {
+      const rendered = await theme.renderLayout("layout", "<p>x</p>", {
         site: { title: "My Site" },
         theme: { author: theme.config.author },
       });
 
       assertStringIncludes(rendered, "<h1>My Site</h1>");
-      assertThrows(
+      await assertRejects(
         () => theme.renderLayout("legacy", "", {}),
         Error,
         'Layout "legacy" not found',

--- a/src/utils/fixtures/tau/v0.9.json
+++ b/src/utils/fixtures/tau/v0.9.json
@@ -1,0 +1,57 @@
+[
+  {
+    "name": "comments are removed and produce no output",
+    "template": "a{# note: internal only #}b",
+    "context": {},
+    "output": "ab"
+  },
+  {
+    "name": "comment syntax does not collide with block keywords",
+    "template": "{#if true}yes{/if}",
+    "context": {},
+    "output": "yes"
+  },
+  {
+    "name": "each else renders when the array is empty",
+    "template": "{#each items as item}{item};{:else}empty{/each}",
+    "context": { "items": [] },
+    "output": "empty"
+  },
+  {
+    "name": "each else does not render when items exist",
+    "template": "{#each items as item}{item};{:else}empty{/each}",
+    "context": { "items": ["a", "b"] },
+    "output": "a;b;"
+  },
+  {
+    "name": "let binds a computed value for the rest of the block",
+    "template": "{#let total = a + b}Total: {total}",
+    "context": { "a": 2, "b": 3 },
+    "output": "Total: 5"
+  },
+  {
+    "name": "component children render in the caller's scope",
+    "template": "{#each posts as post}<Card>{post.title}</Card>{/each}",
+    "context": { "posts": [{ "title": "A" }, { "title": "B" }] },
+    "components": { "Card": "<li>{@children}</li>" },
+    "output": "<li>A</li><li>B</li>"
+  },
+  {
+    "name": "whitespace control trims across a loop",
+    "template": "<ul>\n  {#each items as item-}\n    <li>{item}</li>\n  {-/each}\n</ul>",
+    "context": { "items": ["a", "b"] },
+    "output": "<ul>\n  <li>a</li><li>b</li>\n</ul>"
+  },
+  {
+    "name": "an async context function is awaited without explicit syntax",
+    "template": "{fetchTitle()}",
+    "context": { "fetchTitle": "__async_hello__" },
+    "output": "Async Hello"
+  },
+  {
+    "name": "ternary and nullish coalescing are supported operators",
+    "template": "{flag ? \"yes\" : \"no\"} / {missing ?? \"fallback\"}",
+    "context": { "flag": true },
+    "output": "yes / fallback"
+  }
+]

--- a/src/utils/tau.ts
+++ b/src/utils/tau.ts
@@ -1,6 +1,7 @@
 import { type Node, TauParser } from "./tau_parser.ts";
 import { TauError } from "./tau_error.ts";
 import { utf8ByteLength } from "./text.ts";
+import { BLOCKED_EXPRESSION_NAMES, compileExpression } from "./tau_expr.ts";
 
 /** Options accepted by the Tau template renderer. */
 export interface TauOptions {
@@ -30,7 +31,7 @@ export interface TauLimits {
   maxTemplateBytes: number;
 }
 
-/** Function signature for a Tau value filter. */
+/** Function signature for a Tau value filter. May be sync or async. */
 export type FilterFunction = (
   val: unknown,
   ...args: unknown[]
@@ -38,11 +39,12 @@ export type FilterFunction = (
 type CompiledTemplateFn = (
   context: Record<string, unknown>,
   helpers: TauHelpers,
-) => string;
+) => Promise<string>;
 
 interface TauHelpers {
   filters: Record<string, FilterFunction>;
   append: (target: string[], value: unknown, escape: boolean) => void;
+  get: (obj: unknown, key: unknown, optional: boolean) => unknown;
   isIterable: (value: unknown) => boolean;
   countIteration: () => void;
   renderComponent: (
@@ -50,13 +52,18 @@ interface TauHelpers {
     props: Record<string, unknown>,
     parentContext: Record<string, unknown>,
     target: string[],
-  ) => string;
+  ) => Promise<string>;
   resolveInclude: (
     path: string,
     context: Record<string, unknown>,
     target: string[],
-  ) => string;
+  ) => Promise<string>;
 }
+
+// `new Function` can't construct an async function directly; borrow the
+// AsyncFunction constructor the same way the language spec does.
+const AsyncFunction: FunctionConstructor =
+  Object.getPrototypeOf(async function () {}).constructor;
 
 const templateCache = new Map<string, CompiledTemplateFn>();
 let templateCacheHits = 0;
@@ -78,59 +85,12 @@ interface RenderState {
   componentStack: string[];
 }
 
-const BLOCKED_EXPRESSION_NAMES = new Set([
-  "AsyncFunction",
-  "Deno",
-  "Function",
-  "WebAssembly",
-  "__proto__",
-  "__tauIterable",
-  "constructor",
-  "eval",
-  "helpers",
-  "html",
-  "globalThis",
-  "import",
-  "module",
-  "process",
-  "prototype",
-  "require",
-  "self",
-  "context",
-  "window",
-]);
-
 function hasControlCharacters(value: string): boolean {
   for (let index = 0; index < value.length; index++) {
     const code = value.charCodeAt(index);
     if (code <= 0x1F || code === 0x7F) return true;
   }
   return false;
-}
-
-function assertSafeExpression(expression: string): void {
-  const syntax = expression.replace(
-    /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'/g,
-    '""',
-  );
-  if (
-    /(?:=>|;|`|\\|\+\+|--|\b(?:await|class|delete|function|new|this|yield)\b)/
-      .test(syntax) ||
-    /(?:^|[^=!<>])=(?!=|>)/.test(syntax)
-  ) {
-    throw new TauError(
-      "TAU_UNSAFE_EXPRESSION",
-      `Unsafe Tau expression syntax: "${expression}".`,
-    );
-  }
-  for (const identifier of syntax.match(/[A-Za-z_$][\w$]*/g) ?? []) {
-    if (BLOCKED_EXPRESSION_NAMES.has(identifier)) {
-      throw new TauError(
-        "TAU_UNSAFE_EXPRESSION",
-        `Tau expression access to "${identifier}" is not allowed.`,
-      );
-    }
-  }
 }
 
 function resolveLimits(overrides?: Partial<TauLimits>): TauLimits {
@@ -204,14 +164,36 @@ export function escapeHtml(val: unknown): string {
   ).replace(/"/g, "&quot;").replace(/'/g, "&#39;");
 }
 
-function compileNodes(nodes: Node[]): string {
+const EMPTY_LOCALS: ReadonlySet<string> = new Set();
+
+/** Shared across one compileToFunction call to name child-content buffers uniquely. */
+interface CompileState {
+  nextId: number;
+}
+
+function compileNodes(
+  nodes: Node[],
+  locals: ReadonlySet<string> = EMPTY_LOCALS,
+  target = "html",
+  state: CompileState = { nextId: 0 },
+): string {
   let code = "";
+  // Mutated in place by "let" nodes so a binding is visible to later
+  // siblings in this block without leaking to the caller's scope.
+  let currentLocals = locals;
   for (const node of nodes) {
     if (node.type === "text") {
-      code += `helpers.append(html, ${JSON.stringify(node.value)}, false);\n`;
+      code += `helpers.append(${target}, ${
+        JSON.stringify(node.value)
+      }, false);\n`;
+    } else if (node.type === "let") {
+      const value = compileExpression(node.expression!, currentLocals);
+      code += `const ${node.letName} = ${value};\n`;
+      const nextLocals = new Set(currentLocals);
+      nextLocals.add(node.letName!);
+      currentLocals = nextLocals;
     } else if (node.type === "expression") {
-      let expr = node.expression;
-      assertSafeExpression(expr!);
+      let expr = compileExpression(node.expression!, currentLocals);
       for (const filter of node.filters || []) {
         if (!Object.hasOwn(filters, filter.name)) {
           throw new TauError(
@@ -219,48 +201,70 @@ function compileNodes(nodes: Node[]): string {
             `Unknown Tau filter "${filter.name}".`,
           );
         }
-        for (const arg of filter.args) assertSafeExpression(arg);
-        expr = `helpers.filters.${filter.name}(${
-          [expr, ...filter.args].join(", ")
-        })`;
+        const args = filter.args.map((arg) =>
+          compileExpression(arg, currentLocals)
+        );
+        expr = `(await helpers.filters.${filter.name}(${
+          [expr, ...args].join(", ")
+        }))`;
       }
-      code += `helpers.append(html, ${expr}, true);\n`;
+      code += `helpers.append(${target}, ${expr}, true);\n`;
     } else if (node.type === "html") {
-      assertSafeExpression(node.expression!);
-      code += `helpers.append(html, ${node.expression}, false);\n`;
+      const expr = compileExpression(node.expression!, currentLocals);
+      code += `helpers.append(${target}, ${expr}, false);\n`;
     } else if (node.type === "include") {
-      code += `helpers.resolveInclude(${
+      code += `await helpers.resolveInclude(${
         JSON.stringify(node.includePath)
-      }, context, html);\n`;
+      }, context, ${target});\n`;
     } else if (node.type === "if") {
-      assertSafeExpression(node.condition!);
-      code += `if (${node.condition}) {\n${
-        compileNodes(node.consequent || [])
+      const condition = compileExpression(node.condition!, currentLocals);
+      code += `if (${condition}) {\n${
+        compileNodes(node.consequent || [], currentLocals, target, state)
       }}`;
       if (node.alternate?.length) {
-        code += ` else {\n${compileNodes(node.alternate)}}\n`;
+        code += ` else {\n${
+          compileNodes(node.alternate, currentLocals, target, state)
+        }}\n`;
       } else code += "\n";
     } else if (node.type === "each") {
-      assertSafeExpression(node.array!);
-      code += `{\nconst __tauIterable = ${node.array};\n`;
+      const array = compileExpression(node.array!, currentLocals);
+      const loopLocals = new Set(currentLocals);
+      loopLocals.add(node.item!);
+      if (node.indexVar) loopLocals.add(node.indexVar);
+      const hasElse = (node.alternate?.length ?? 0) > 0;
+      code += `{\nconst __tauIterable = ${array};\n`;
+      if (hasElse) code += `let __tauHadItems = false;\n`;
       code += `if (helpers.isIterable(__tauIterable)) {\n`;
       if (node.indexVar) code += `  let ${node.indexVar} = 0;\n`;
-      code +=
-        `  for (const ${node.item} of __tauIterable) {\n    helpers.countIteration();\n${
-          compileNodes(node.consequent || [])
-        }`;
+      code += `  for (const ${node.item} of __tauIterable) {\n${
+        hasElse ? "    __tauHadItems = true;\n" : ""
+      }    helpers.countIteration();\n${
+        compileNodes(node.consequent || [], loopLocals, target, state)
+      }`;
       if (node.indexVar) code += `    ${node.indexVar}++;\n`;
-      code += `  }\n}\n}\n`;
+      code += `  }\n}\n`;
+      if (hasElse) {
+        code += `if (!__tauHadItems) {\n${
+          compileNodes(node.alternate || [], currentLocals, target, state)
+        }}\n`;
+      }
+      code += `}\n`;
     } else if (node.type === "component") {
-      const propsObj = `{ ${
-        Object.entries(node.props || {}).map(([k, v]) => {
-          assertSafeExpression(v);
-          return `${JSON.stringify(k)}: ${v}`;
-        }).join(", ")
-      } }`;
-      code += `helpers.renderComponent(${
+      const propsEntries = Object.entries(node.props || {}).map(([k, v]) => {
+        const value = compileExpression(v, currentLocals);
+        return `${JSON.stringify(k)}: ${value}`;
+      });
+      if (node.consequent && node.consequent.length > 0) {
+        const childTarget = `__tauChildren${state.nextId++}`;
+        code += `const ${childTarget} = [];\n${
+          compileNodes(node.consequent, currentLocals, childTarget, state)
+        }`;
+        propsEntries.push(`children: ${childTarget}.join("")`);
+      }
+      const propsObj = `{ ${propsEntries.join(", ")} }`;
+      code += `await helpers.renderComponent(${
         JSON.stringify(node.componentName)
-      }, ${propsObj}, context, html);\n`;
+      }, ${propsObj}, context, ${target});\n`;
     }
   }
   return code;
@@ -272,11 +276,11 @@ export function compileToFunction(
 ): CompiledTemplateFn {
   const body = compileNodes(new TauParser(template, filePath).parseBlock());
   try {
-    return new Function(
+    return new AsyncFunction(
       "context",
       "helpers",
-      `const html = []; with (context) {\n${body}\n} return html.join("");`,
-    ) as CompiledTemplateFn;
+      `const html = [];\n${body}\nreturn html.join("");`,
+    ) as unknown as CompiledTemplateFn;
   } catch (err) {
     throw new TauError(
       "TAU_UNSAFE_EXPRESSION",
@@ -342,12 +346,12 @@ export function clearTauCache(): void {
   templateCacheEvictions = 0;
 }
 
-function renderWithCompiledTemplate(
+async function renderWithCompiledTemplate(
   renderFn: CompiledTemplateFn,
   options: TauOptions,
   componentFnCache: Map<string, CompiledTemplateFn>,
   state: RenderState,
-): string {
+): Promise<string> {
   state.depth++;
   if (state.depth > state.limits.maxDepth) {
     state.depth--;
@@ -370,6 +374,16 @@ function renderWithCompiledTemplate(
       }
       target.push(output);
     },
+    get: (obj: unknown, key: unknown, optional: boolean) => {
+      if (optional && (obj === null || obj === undefined)) return undefined;
+      if (typeof key === "string" && BLOCKED_EXPRESSION_NAMES.has(key)) {
+        throw new TauError(
+          "TAU_UNSAFE_EXPRESSION",
+          `Tau expression access to "${key}" is not allowed.`,
+        );
+      }
+      return (obj as Record<string, unknown>)[key as string];
+    },
     isIterable: (value: unknown) =>
       value != null &&
       typeof (value as { [Symbol.iterator]?: unknown })[Symbol.iterator] ===
@@ -383,7 +397,7 @@ function renderWithCompiledTemplate(
         );
       }
     },
-    resolveInclude: (
+    resolveInclude: async (
       path: string,
       ctx: Record<string, unknown>,
       target: string[],
@@ -406,7 +420,7 @@ function renderWithCompiledTemplate(
       try {
         const includedTemplate = options.includeResolver(path);
         assertTemplateSize(includedTemplate, state.limits);
-        const output = renderWithCompiledTemplate(
+        const output = await renderWithCompiledTemplate(
           getCompiledTemplate(includedTemplate, path),
           {
             ...options,
@@ -423,7 +437,7 @@ function renderWithCompiledTemplate(
         state.includeStack.pop();
       }
     },
-    renderComponent: (
+    renderComponent: async (
       name: string,
       props: Record<string, unknown>,
       parentContext: Record<string, unknown>,
@@ -467,7 +481,7 @@ function renderWithCompiledTemplate(
           : {};
       state.componentStack.push(name);
       try {
-        const output = renderWithCompiledTemplate(
+        const output = await renderWithCompiledTemplate(
           componentRenderFn,
           {
             ...options,
@@ -491,21 +505,9 @@ function renderWithCompiledTemplate(
     },
   };
 
-  const contextProxy = new Proxy(options.context, {
-    has: (_, key) =>
-      typeof key !== "symbol" &&
-      !["html", "helpers", "context"].includes(key as string),
-    get: (target, key) => {
-      if (key === Symbol.unscopables) return undefined;
-      if (Object.hasOwn(target, key)) return target[key as string];
-      if (key in helpers) return undefined;
-      return undefined;
-    },
-  });
-
   try {
     try {
-      return renderFn(contextProxy, helpers);
+      return await renderFn(options.context, helpers);
     } catch (error) {
       if (error instanceof TauError) throw error;
       throw new TauError(
@@ -535,13 +537,17 @@ function assertTemplateSize(template: string, limits: TauLimits): void {
 /**
  * Renders a Tau template with the supplied context and components.
  *
+ * Async because template expressions may call a context-supplied async
+ * function (`{someAsyncFn()}`); the result is awaited implicitly, so a sync
+ * function works too. Filters may also be async.
+ *
  * @param options Template source, context, components, and optional limits.
  * @returns The rendered HTML string.
  */
-export function render(options: TauOptions): string {
+export async function render(options: TauOptions): Promise<string> {
   const limits = resolveLimits(options.limits);
   assertTemplateSize(options.template, limits);
-  return renderWithCompiledTemplate(
+  return await renderWithCompiledTemplate(
     getCompiledTemplate(options.template, options.filePath),
     options,
     new Map(),

--- a/src/utils/tau_cache_test.ts
+++ b/src/utils/tau_cache_test.ts
@@ -2,10 +2,10 @@ import { assertEquals } from "@std/assert";
 import { clearTauCache, getTauCacheStats, render } from "./tau.ts";
 
 export function registerTauCacheTests(): void {
-  Deno.test("tau cache: remains bounded and reports LRU pressure", () => {
+  Deno.test("tau cache: remains bounded and reports LRU pressure", async () => {
     clearTauCache();
     for (let index = 0; index < 700; index++) {
-      render({
+      await render({
         template: `<p>${index}:{value}</p>${"x".repeat(512)}`,
         context: { value: index },
         components: {},
@@ -19,15 +19,15 @@ export function registerTauCacheTests(): void {
     assertEquals(stats.evictions, 188);
   });
 
-  Deno.test("tau cache: records hits and can release retained templates", () => {
+  Deno.test("tau cache: records hits and can release retained templates", async () => {
     clearTauCache();
     const options = {
       template: "<p>{value}</p>",
       context: { value: "x" },
       components: {},
     };
-    render(options);
-    render(options);
+    await render(options);
+    await render(options);
 
     assertEquals(getTauCacheStats(), {
       size: 1,

--- a/src/utils/tau_conformance_test.ts
+++ b/src/utils/tau_conformance_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { render } from "./tau.ts";
 import { TauError, type TauErrorCode } from "./tau_error.ts";
 
@@ -19,22 +19,44 @@ function loadCases(version: string): ConformanceCase[] {
   return JSON.parse(Deno.readTextFileSync(url)) as ConformanceCase[];
 }
 
-export function registerTauConformanceTests(): void {
-  for (const testCase of loadCases("v0.8")) {
-    Deno.test(`tau conformance v0.8: ${testCase.name}`, () => {
+// JSON fixtures can't encode functions; this sentinel string stands in for a
+// context-supplied async function so the "async call is awaited" case can be
+// expressed declaratively like every other fixture.
+const ASYNC_HELLO_SENTINEL = "__async_hello__";
+
+function resolveContext(
+  context: Record<string, unknown>,
+): Record<string, unknown> {
+  const resolved: Record<string, unknown> = { ...context };
+  for (const [key, value] of Object.entries(resolved)) {
+    if (value === ASYNC_HELLO_SENTINEL) {
+      resolved[key] = () => Promise.resolve("Async Hello");
+    }
+  }
+  return resolved;
+}
+
+function registerVersion(version: string): void {
+  for (const testCase of loadCases(version)) {
+    Deno.test(`tau conformance ${version}: ${testCase.name}`, async () => {
       const execute = () =>
         render({
           template: testCase.template,
-          context: testCase.context,
+          context: resolveContext(testCase.context),
           components: testCase.components ?? {},
         });
 
       if (testCase.errorCode) {
-        const error = assertThrows(execute, TauError);
+        const error = await assertRejects(execute, TauError);
         assertEquals(error.code, testCase.errorCode);
       } else {
-        assertEquals(execute(), testCase.output);
+        assertEquals(await execute(), testCase.output);
       }
     });
   }
+}
+
+export function registerTauConformanceTests(): void {
+  registerVersion("v0.8");
+  registerVersion("v0.9");
 }

--- a/src/utils/tau_expr.ts
+++ b/src/utils/tau_expr.ts
@@ -1,0 +1,595 @@
+import { TauError } from "./tau_error.ts";
+
+/**
+ * Identifiers Tau expressions may never resolve, whether accessed as a bare
+ * identifier or as a static property name. This is the same defense-in-depth
+ * blocklist Tau has always enforced; it is now checked structurally against
+ * a parsed AST instead of scanned as text, which also closes the dynamic
+ * `obj["constructor"]` bypass class (see {@link TauHelpers.get} in tau.ts).
+ */
+export const BLOCKED_EXPRESSION_NAMES: ReadonlySet<string> = new Set([
+  "AsyncFunction",
+  "Deno",
+  "Function",
+  "WebAssembly",
+  "__proto__",
+  "__tauIterable",
+  "constructor",
+  "eval",
+  "helpers",
+  "html",
+  "globalThis",
+  "import",
+  "module",
+  "process",
+  "prototype",
+  "require",
+  "self",
+  "context",
+  "window",
+]);
+
+/**
+ * JavaScript reserved words Tau expressions reject when used as a bare
+ * identifier (a primary expression value), matching the language subset
+ * documented in `docs/tau_syntax.md`.
+ */
+const RESERVED_KEYWORDS: ReadonlySet<string> = new Set([
+  "await",
+  "class",
+  "delete",
+  "function",
+  "new",
+  "this",
+  "yield",
+]);
+
+/** A parsed Tau expression AST node. */
+export type TauExprNode =
+  | { type: "Literal"; value: string | number | boolean | null | undefined }
+  | { type: "Identifier"; name: string }
+  | {
+    type: "Member";
+    object: TauExprNode;
+    property: TauExprNode | string;
+    computed: boolean;
+    optional: boolean;
+  }
+  | {
+    type: "Call";
+    callee: TauExprNode;
+    args: TauExprNode[];
+    optional: boolean;
+  }
+  | { type: "Unary"; operator: "!" | "-" | "+"; argument: TauExprNode }
+  | { type: "Binary"; operator: string; left: TauExprNode; right: TauExprNode }
+  | {
+    type: "Logical";
+    operator: "&&" | "||" | "??";
+    left: TauExprNode;
+    right: TauExprNode;
+  }
+  | {
+    type: "Conditional";
+    test: TauExprNode;
+    consequent: TauExprNode;
+    alternate: TauExprNode;
+  };
+
+type TokenType = "ident" | "number" | "string" | "punct";
+interface Token {
+  type: TokenType;
+  value: string;
+  pos: number;
+}
+
+const PUNCTUATORS = [
+  "===",
+  "!==",
+  "?.",
+  "??",
+  "==",
+  "!=",
+  "<=",
+  ">=",
+  "&&",
+  "||",
+  ".",
+  ",",
+  "(",
+  ")",
+  "[",
+  "]",
+  "!",
+  "-",
+  "+",
+  "*",
+  "/",
+  "%",
+  "<",
+  ">",
+  "?",
+  ":",
+].sort((a, b) => b.length - a.length);
+
+const BINARY_PRECEDENCE: Record<string, number> = {
+  "??": 1,
+  "||": 1,
+  "&&": 2,
+  "==": 3,
+  "!=": 3,
+  "===": 3,
+  "!==": 3,
+  "<": 4,
+  "<=": 4,
+  ">": 4,
+  ">=": 4,
+  "+": 5,
+  "-": 5,
+  "*": 6,
+  "/": 6,
+  "%": 6,
+};
+
+function isDigit(char: string): boolean {
+  return char >= "0" && char <= "9";
+}
+
+function isIdentifierStart(char: string): boolean {
+  return /[A-Za-z_$]/.test(char);
+}
+
+function isIdentifierPart(char: string): boolean {
+  return /[A-Za-z0-9_$]/.test(char);
+}
+
+function fail(message: string, source: string): never {
+  throw new TauError(
+    "TAU_UNSAFE_EXPRESSION",
+    `${message} in Tau expression: "${source}".`,
+  );
+}
+
+function tokenize(source: string): Token[] {
+  const tokens: Token[] = [];
+  let pos = 0;
+
+  const readString = (quote: string): string => {
+    const start = pos;
+    pos++;
+    let value = "";
+    while (true) {
+      if (pos >= source.length) {
+        fail("Unterminated string literal", source);
+      }
+      const char = source[pos];
+      if (char === quote) {
+        pos++;
+        break;
+      }
+      if (char === "\\") {
+        pos++;
+        const escaped = source[pos];
+        if (escaped === undefined) fail("Unterminated string literal", source);
+        switch (escaped) {
+          case "n":
+            value += "\n";
+            break;
+          case "r":
+            value += "\r";
+            break;
+          case "t":
+            value += "\t";
+            break;
+          case "b":
+            value += "\b";
+            break;
+          case "f":
+            value += "\f";
+            break;
+          case "v":
+            value += "\v";
+            break;
+          case "0":
+            value += "\0";
+            break;
+          default:
+            value += escaped;
+        }
+        pos++;
+        continue;
+      }
+      value += char;
+      pos++;
+    }
+    void start;
+    return value;
+  };
+
+  const readNumber = (): number => {
+    const start = pos;
+    while (isDigit(source[pos] ?? "")) pos++;
+    if (source[pos] === "." && isDigit(source[pos + 1] ?? "")) {
+      pos++;
+      while (isDigit(source[pos] ?? "")) pos++;
+    }
+    if (source[pos] === "e" || source[pos] === "E") {
+      const save = pos;
+      pos++;
+      if (source[pos] === "+" || source[pos] === "-") pos++;
+      if (isDigit(source[pos] ?? "")) {
+        while (isDigit(source[pos] ?? "")) pos++;
+      } else {
+        pos = save;
+      }
+    }
+    return Number(source.slice(start, pos));
+  };
+
+  while (pos < source.length) {
+    const char = source[pos];
+    if (char === " " || char === "\t" || char === "\n" || char === "\r") {
+      pos++;
+      continue;
+    }
+    if (char === "`" || char === ";" || char === "\\") {
+      fail(`Unexpected character "${char}"`, source);
+    }
+    if (char === "=") {
+      // Only "==" / "===" are valid; bare "=" (assignment) is rejected, and
+      // this also structurally rejects "=>" (arrow functions).
+      if (source[pos + 1] === "=") {
+        tokens.push({
+          type: "punct",
+          value: source[pos + 2] === "=" ? "===" : "==",
+          pos,
+        });
+        pos += source[pos + 2] === "=" ? 3 : 2;
+        continue;
+      }
+      fail('Assignment ("=") is not allowed', source);
+    }
+    if (char === "+" && source[pos + 1] === "+") {
+      fail('Increment ("++") is not allowed', source);
+    }
+    if (char === "-" && source[pos + 1] === "-") {
+      fail('Decrement ("--") is not allowed', source);
+    }
+    if (char === '"' || char === "'") {
+      const value = readString(char);
+      tokens.push({ type: "string", value, pos });
+      continue;
+    }
+    if (isDigit(char)) {
+      const startPos = pos;
+      const value = readNumber();
+      tokens.push({ type: "number", value: String(value), pos: startPos });
+      continue;
+    }
+    if (isIdentifierStart(char)) {
+      const start = pos;
+      pos++;
+      while (pos < source.length && isIdentifierPart(source[pos])) pos++;
+      tokens.push({
+        type: "ident",
+        value: source.slice(start, pos),
+        pos: start,
+      });
+      continue;
+    }
+    const punct = PUNCTUATORS.find((p) => source.startsWith(p, pos));
+    if (punct) {
+      tokens.push({ type: "punct", value: punct, pos });
+      pos += punct.length;
+      continue;
+    }
+    fail(`Unexpected character "${char}"`, source);
+  }
+
+  return tokens;
+}
+
+function assertAllowedPropertyName(name: string, source: string): void {
+  if (BLOCKED_EXPRESSION_NAMES.has(name)) {
+    throw new TauError(
+      "TAU_UNSAFE_EXPRESSION",
+      `Tau expression access to "${name}" is not allowed.`,
+    );
+  }
+  void source;
+}
+
+class ExprParser {
+  private index = 0;
+  constructor(
+    private readonly tokens: Token[],
+    private readonly source: string,
+  ) {}
+
+  private peek(offset = 0): Token | undefined {
+    return this.tokens[this.index + offset];
+  }
+
+  private advance(): Token {
+    const token = this.tokens[this.index];
+    if (!token) fail("Unexpected end of expression", this.source);
+    this.index++;
+    return token;
+  }
+
+  private matchPunct(value: string): boolean {
+    const token = this.peek();
+    return !!token && token.type === "punct" && token.value === value;
+  }
+
+  private expectPunct(value: string): void {
+    if (!this.matchPunct(value)) {
+      fail(`Expected "${value}"`, this.source);
+    }
+    this.advance();
+  }
+
+  parseTop(): TauExprNode {
+    if (this.tokens.length === 0) {
+      fail("Unexpected end of expression", this.source);
+    }
+    const node = this.parseConditional();
+    if (this.index < this.tokens.length) {
+      fail(`Unexpected token "${this.peek()!.value}"`, this.source);
+    }
+    return node;
+  }
+
+  private parseConditional(): TauExprNode {
+    const test = this.parseBinary(1);
+    if (this.matchPunct("?")) {
+      this.advance();
+      const consequent = this.parseConditional();
+      this.expectPunct(":");
+      const alternate = this.parseConditional();
+      return { type: "Conditional", test, consequent, alternate };
+    }
+    return test;
+  }
+
+  private parseBinary(minPrec: number): TauExprNode {
+    let left = this.parseUnary();
+    while (true) {
+      const token = this.peek();
+      if (!token || token.type !== "punct") break;
+      const prec = BINARY_PRECEDENCE[token.value];
+      if (prec === undefined || prec < minPrec) break;
+      this.advance();
+      const right = this.parseBinary(prec + 1);
+      if (
+        token.value === "&&" || token.value === "||" || token.value === "??"
+      ) {
+        left = {
+          type: "Logical",
+          operator: token.value as "&&" | "||" | "??",
+          left,
+          right,
+        };
+      } else {
+        left = { type: "Binary", operator: token.value, left, right };
+      }
+    }
+    return left;
+  }
+
+  private parseUnary(): TauExprNode {
+    if (this.matchPunct("!") || this.matchPunct("-") || this.matchPunct("+")) {
+      const operator = this.advance().value as "!" | "-" | "+";
+      const argument = this.parseUnary();
+      return { type: "Unary", operator, argument };
+    }
+    return this.parsePostfix();
+  }
+
+  private parseArgs(): TauExprNode[] {
+    this.expectPunct("(");
+    const args: TauExprNode[] = [];
+    if (!this.matchPunct(")")) {
+      args.push(this.parseConditional());
+      while (this.matchPunct(",")) {
+        this.advance();
+        args.push(this.parseConditional());
+      }
+    }
+    this.expectPunct(")");
+    return args;
+  }
+
+  private parsePropertyName(): string {
+    const token = this.peek();
+    if (!token || (token.type !== "ident")) {
+      fail("Expected a property name", this.source);
+    }
+    this.advance();
+    assertAllowedPropertyName(token.value, this.source);
+    return token.value;
+  }
+
+  private parsePostfix(): TauExprNode {
+    let expr = this.parsePrimary();
+    while (true) {
+      if (this.matchPunct(".")) {
+        this.advance();
+        const name = this.parsePropertyName();
+        expr = {
+          type: "Member",
+          object: expr,
+          property: name,
+          computed: false,
+          optional: false,
+        };
+      } else if (this.matchPunct("?.")) {
+        this.advance();
+        if (this.matchPunct("(")) {
+          const args = this.parseArgs();
+          expr = { type: "Call", callee: expr, args, optional: true };
+        } else if (this.matchPunct("[")) {
+          this.advance();
+          const property = this.parseConditional();
+          this.expectPunct("]");
+          this.checkComputedLiteral(property);
+          expr = {
+            type: "Member",
+            object: expr,
+            property,
+            computed: true,
+            optional: true,
+          };
+        } else {
+          const name = this.parsePropertyName();
+          expr = {
+            type: "Member",
+            object: expr,
+            property: name,
+            computed: false,
+            optional: true,
+          };
+        }
+      } else if (this.matchPunct("[")) {
+        this.advance();
+        const property = this.parseConditional();
+        this.expectPunct("]");
+        this.checkComputedLiteral(property);
+        expr = {
+          type: "Member",
+          object: expr,
+          property,
+          computed: true,
+          optional: false,
+        };
+      } else if (this.matchPunct("(")) {
+        const args = this.parseArgs();
+        expr = { type: "Call", callee: expr, args, optional: false };
+      } else {
+        break;
+      }
+    }
+    return expr;
+  }
+
+  private checkComputedLiteral(node: TauExprNode): void {
+    if (node.type === "Literal" && typeof node.value === "string") {
+      assertAllowedPropertyName(node.value, this.source);
+    }
+  }
+
+  private parsePrimary(): TauExprNode {
+    const token = this.peek();
+    if (!token) fail("Unexpected end of expression", this.source);
+
+    if (token.type === "number") {
+      this.advance();
+      return { type: "Literal", value: Number(token.value) };
+    }
+    if (token.type === "string") {
+      this.advance();
+      return { type: "Literal", value: token.value };
+    }
+    if (token.type === "punct" && token.value === "(") {
+      this.advance();
+      const inner = this.parseConditional();
+      this.expectPunct(")");
+      return inner;
+    }
+    if (token.type === "ident") {
+      this.advance();
+      switch (token.value) {
+        case "true":
+          return { type: "Literal", value: true };
+        case "false":
+          return { type: "Literal", value: false };
+        case "null":
+          return { type: "Literal", value: null };
+        case "undefined":
+          return { type: "Literal", value: undefined };
+      }
+      if (RESERVED_KEYWORDS.has(token.value)) {
+        throw new TauError(
+          "TAU_UNSAFE_EXPRESSION",
+          `Tau expression keyword "${token.value}" is not allowed.`,
+        );
+      }
+      return { type: "Identifier", name: token.value };
+    }
+    fail(`Unexpected token "${token.value}"`, this.source);
+  }
+}
+
+/** Parses a Tau expression string into an AST, enforcing Tau's language subset. */
+export function parseTauExpression(source: string): TauExprNode {
+  const tokens = tokenize(source);
+  return new ExprParser(tokens, source).parseTop();
+}
+
+/**
+ * Compiles a Tau expression string to a JS source snippet safe to splice
+ * into a compiled template function body.
+ *
+ * Free identifiers become explicit `context.name` reads (no `with`); names
+ * in `locals` (bound `{#each}` item/index variables) are emitted bare since
+ * they resolve to real lexical bindings in the generated function.
+ */
+export function compileExpression(
+  source: string,
+  locals: ReadonlySet<string>,
+): string {
+  const ast = parseTauExpression(source);
+  return emitExpr(ast, locals);
+}
+
+function emitExpr(node: TauExprNode, locals: ReadonlySet<string>): string {
+  switch (node.type) {
+    case "Literal":
+      return node.value === undefined
+        ? "undefined"
+        : JSON.stringify(node.value);
+    case "Identifier": {
+      if (locals.has(node.name)) return node.name;
+      if (BLOCKED_EXPRESSION_NAMES.has(node.name)) {
+        throw new TauError(
+          "TAU_UNSAFE_EXPRESSION",
+          `Tau expression access to "${node.name}" is not allowed.`,
+        );
+      }
+      return `context.${node.name}`;
+    }
+    case "Member": {
+      const objectSrc = emitExpr(node.object, locals);
+      if (node.computed) {
+        const propertySrc = emitExpr(node.property as TauExprNode, locals);
+        return `helpers.get(${objectSrc}, ${propertySrc}, ${node.optional})`;
+      }
+      return `${objectSrc}${node.optional ? "?." : "."}${node
+        .property as string}`;
+    }
+    case "Call": {
+      const calleeSrc = emitExpr(node.callee, locals);
+      const argsSrc = node.args.map((arg) => emitExpr(arg, locals)).join(", ");
+      // Awaiting unconditionally lets a context-supplied function be either
+      // sync or async without special syntax; `await` on a non-promise
+      // value just resolves it on the next microtask.
+      return node.optional
+        ? `(await ${calleeSrc}?.(${argsSrc}))`
+        : `(await ${calleeSrc}(${argsSrc}))`;
+    }
+    case "Unary":
+      return `(${node.operator}${emitExpr(node.argument, locals)})`;
+    case "Binary":
+      return `(${emitExpr(node.left, locals)} ${node.operator} ${
+        emitExpr(node.right, locals)
+      })`;
+    case "Logical":
+      return `(${emitExpr(node.left, locals)} ${node.operator} ${
+        emitExpr(node.right, locals)
+      })`;
+    case "Conditional":
+      return `(${emitExpr(node.test, locals)} ? ${
+        emitExpr(node.consequent, locals)
+      } : ${emitExpr(node.alternate, locals)})`;
+  }
+}

--- a/src/utils/tau_fuzz_test.ts
+++ b/src/utils/tau_fuzz_test.ts
@@ -21,11 +21,11 @@ function randomString(random: () => number, length: number): string {
 }
 
 export function registerTauFuzzTests(): void {
-  Deno.test("tau property: escaped interpolation never emits raw HTML delimiters", () => {
+  Deno.test("tau property: escaped interpolation never emits raw HTML delimiters", async () => {
     const random = createRandom(0x54415508);
     for (let index = 0; index < 1_000; index++) {
       const value = randomString(random, Math.floor(random() * 80));
-      const output = render({
+      const output = await render({
         template: "{value}",
         context: { value },
         components: {},
@@ -33,7 +33,7 @@ export function registerTauFuzzTests(): void {
       assertEquals(output, escapeHtml(value));
       assertEquals(
         output,
-        render({
+        await render({
           template: "{value}",
           context: { value },
           components: {},
@@ -56,11 +56,11 @@ export function registerTauFuzzTests(): void {
     }
   });
 
-  Deno.test("tau adversarial: parser rejects excessive syntax depth", () => {
+  Deno.test("tau adversarial: parser rejects excessive syntax depth", async () => {
     const template = `${"{#if true}".repeat(300)}x${"{/if}".repeat(300)}`;
-    const error = (() => {
+    const error = await (async () => {
       try {
-        render({ template, context: {}, components: {} });
+        await render({ template, context: {}, components: {} });
       } catch (caught) {
         return caught;
       }
@@ -69,15 +69,15 @@ export function registerTauFuzzTests(): void {
     assertEquals(error.code, "TAU_LIMIT_DEPTH");
   });
 
-  Deno.test("tau adversarial: infinite iterables stop at the shared limit", () => {
+  Deno.test("tau adversarial: infinite iterables stop at the shared limit", async () => {
     const infinite = {
       *[Symbol.iterator]() {
         while (true) yield "x";
       },
     };
-    const error = (() => {
+    const error = await (async () => {
       try {
-        render({
+        await render({
           template: "{#each values as value}{value}{/each}",
           context: { values: infinite },
           components: {},
@@ -91,10 +91,10 @@ export function registerTauFuzzTests(): void {
     assertEquals(error.code, "TAU_LIMIT_ITERATIONS");
   });
 
-  Deno.test("tau property: output never exceeds its configured byte limit", () => {
+  Deno.test("tau property: output never exceeds its configured byte limit", async () => {
     const limit = 128;
     try {
-      const output = render({
+      const output = await render({
         template: "{#each values as value}{value}{/each}",
         context: { values: Array(100).fill("😀") },
         components: {},

--- a/src/utils/tau_parser.ts
+++ b/src/utils/tau_parser.ts
@@ -7,6 +7,7 @@ export interface Node {
     | "html"
     | "if"
     | "each"
+    | "let"
     | "component"
     | "include";
   value?: string;
@@ -16,11 +17,16 @@ export interface Node {
   array?: string;
   item?: string;
   indexVar?: string;
+  letName?: string;
   consequent?: Node[];
   alternate?: Node[];
   componentName?: string;
   props?: Record<string, string>;
   includePath?: string;
+  /** Whitespace-control: trim the sibling text immediately before this node. */
+  trimBefore?: boolean;
+  /** Whitespace-control: trim the sibling text immediately after this node. */
+  trimAfter?: boolean;
 }
 
 const IDENTIFIER_PATTERN = /^[A-Za-z_$][\w$]*$/;
@@ -73,6 +79,47 @@ function splitTopLevel(
   }
   parts.push(value.substring(start));
   return parts;
+}
+
+/**
+ * Whitespace-control tag variants. A tag written as `{-#if `/`{-:else}`/etc.
+ * trims the trailing whitespace of the text immediately before it; a tag
+ * written as `{#if cond-}`/`{:else-}`/etc. trims the leading whitespace of
+ * the text immediately after it. Scoped to `{#if}`, `{:else if}`, `{:else}`,
+ * `{/if}`, `{#each}`, and `{/each}`.
+ */
+function tagVariants(literal: string): string[] {
+  const withBefore = "{-" + literal.slice(1);
+  const withAfter = literal.slice(0, -1) + "-}";
+  const withBoth = "{-" + literal.slice(1, -1) + "-}";
+  return [withBoth, withBefore, withAfter, literal];
+}
+
+function prefixVariants(prefix: string): string[] {
+  return ["{-" + prefix.slice(1), prefix];
+}
+
+function trimTrailingWhitespace(nodes: Node[]): void {
+  const last = nodes[nodes.length - 1];
+  if (last?.type === "text" && last.value !== undefined) {
+    last.value = last.value.replace(/\s+$/, "");
+  }
+}
+
+function trimLeadingWhitespace(nodes: Node[]): void {
+  const first = nodes[0];
+  if (first?.type === "text" && first.value !== undefined) {
+    first.value = first.value.replace(/^\s+/, "");
+  }
+}
+
+function extractTrimSuffix(
+  raw: string,
+): { content: string; trimAfter: boolean } {
+  if (raw.endsWith("-")) {
+    return { content: raw.slice(0, -1).trim(), trimAfter: true };
+  }
+  return { content: raw, trimAfter: false };
 }
 
 function assertIdentifier(
@@ -193,6 +240,7 @@ export class TauParser {
   private readonly filePath?: string;
   private pos = 0;
   private depth = 0;
+  private pendingTrimStart = false;
 
   constructor(
     input: string,
@@ -227,6 +275,26 @@ export class TauParser {
     else this.throwError(`Expected "${str}"`);
   }
 
+  private matchBlockKeyword(): boolean {
+    return this.match("{#if ") || this.match("{#each ") || this.match("{#let ");
+  }
+
+  private matchCommentStart(): boolean {
+    return this.match("{#") && !this.matchBlockKeyword();
+  }
+
+  private parseCommentBlock(): void {
+    this.consume("{#");
+    while (this.pos < this.input.length && !this.match("#}")) this.pos++;
+    if (!this.match("#}")) {
+      this.throwError(
+        'Unclosed comment. Expected "#}".',
+        "TAU_PARSE_UNCLOSED_BLOCK",
+      );
+    }
+    this.consume("#}");
+  }
+
   public parseBlock(endTags: string[] = []): Node[] {
     this.depth++;
     if (this.depth > this.maxParseDepth) {
@@ -238,13 +306,32 @@ export class TauParser {
     const nodes: Node[] = [];
     try {
       while (this.pos < this.input.length) {
+        if (this.pendingTrimStart) {
+          this.pendingTrimStart = false;
+          while (
+            this.pos < this.input.length && /\s/.test(this.input[this.pos])
+          ) this.pos++;
+        }
         if (endTags.some((tag) => this.match(tag))) break;
 
-        if (this.match("{#if ")) nodes.push(this.parseIfBlock());
-        else if (this.match("{#each ")) nodes.push(this.parseEachBlock());
+        if (this.match("{#if ") || this.match("{-#if ")) {
+          const node = this.parseIfBlock();
+          if (node.trimBefore) trimTrailingWhitespace(nodes);
+          nodes.push(node);
+          if (node.trimAfter) this.pendingTrimStart = true;
+        } else if (this.match("{#each ") || this.match("{-#each ")) {
+          const node = this.parseEachBlock();
+          if (node.trimBefore) trimTrailingWhitespace(nodes);
+          nodes.push(node);
+          if (node.trimAfter) this.pendingTrimStart = true;
+        } else if (this.match("{#let ")) nodes.push(this.parseLetBlock());
+        else if (this.matchCommentStart()) this.parseCommentBlock();
         else if (this.match("{@include ")) nodes.push(this.parseIncludeBlock());
         else if (this.match("{@html ")) nodes.push(this.parseHtmlBlock());
-        else if (
+        else if (this.match("{@children}")) {
+          this.consume("{@children}");
+          nodes.push({ type: "html", expression: "children" });
+        } else if (
           this.peek() === "{" && !["#", "/", ":", "@"].includes(this.peek(1))
         ) nodes.push(this.parseVariableBlock());
         else if (this.peek() === "<" && /[A-Z]/.test(this.peek(1))) {
@@ -257,46 +344,100 @@ export class TauParser {
     }
   }
 
-  private parseIfBlock(prefix = "{#if "): Node {
+  private consumeTagPrefix(prefix: string): boolean {
+    const withDash = "{-" + prefix.slice(1);
+    if (this.match(withDash)) {
+      this.pos += withDash.length;
+      return true;
+    }
     this.consume(prefix);
+    return false;
+  }
+
+  private parseIfBlock(prefix = "{#if "): Node {
+    const trimBefore = this.consumeTagPrefix(prefix);
     const start = this.pos;
     while (this.pos < this.input.length && this.input[this.pos] !== "}") {
       this.pos++;
     }
-    const condition = this.input.substring(start, this.pos).trim();
+    const raw = this.input.substring(start, this.pos).trim();
     this.consume("}");
+    const { content: condition, trimAfter: trimAfterOpen } = extractTrimSuffix(
+      raw,
+    );
     if (!condition) {
       this.throwError("If condition cannot be empty.", "TAU_PARSE_EMPTY");
     }
 
-    const consequent = this.parseBlock(["{:else if ", "{:else}", "{/if}"]);
-    let alternate: Node[] = [];
+    const elseIfPrefixes = prefixVariants("{:else if ");
+    const elseVariants = tagVariants("{:else}");
+    const closeVariants = tagVariants("{/if}");
+    const consequent = this.parseBlock([
+      ...elseIfPrefixes,
+      ...elseVariants,
+      ...closeVariants,
+    ]);
+    if (trimAfterOpen) trimLeadingWhitespace(consequent);
 
-    if (this.match("{:else if ")) {
-      alternate = [this.parseIfBlock("{:else if ")];
-    } else if (this.match("{:else}")) {
-      this.consume("{:else}");
-      alternate = this.parseBlock(["{/if}"]);
-      this.consume("{/if}");
-    } else if (this.match("{/if}")) {
-      this.consume("{/if}");
+    let alternate: Node[] = [];
+    let trimAfter = false;
+
+    const elseIfMatch = elseIfPrefixes.find((p) => this.match(p));
+    const elseMatch = elseVariants.find((v) => this.match(v));
+    const closeMatch = closeVariants.find((v) => this.match(v));
+
+    if (elseIfMatch) {
+      if (elseIfMatch.startsWith("{-")) trimTrailingWhitespace(consequent);
+      const nested = this.parseIfBlock("{:else if ");
+      alternate = [nested];
+      trimAfter = nested.trimAfter === true;
+    } else if (elseMatch) {
+      if (elseMatch.startsWith("{-")) trimTrailingWhitespace(consequent);
+      this.pos += elseMatch.length;
+      const innerCloseVariants = tagVariants("{/if}");
+      alternate = this.parseBlock(innerCloseVariants);
+      if (elseMatch.endsWith("-}")) trimLeadingWhitespace(alternate);
+      const innerClose = innerCloseVariants.find((v) => this.match(v));
+      if (!innerClose) {
+        this.throwError(
+          'Unclosed if block. Expected "{/if}".',
+          "TAU_PARSE_UNCLOSED_BLOCK",
+        );
+      }
+      if (innerClose.startsWith("{-")) trimTrailingWhitespace(alternate);
+      this.pos += innerClose.length;
+      trimAfter = innerClose.endsWith("-}");
+    } else if (closeMatch) {
+      if (closeMatch.startsWith("{-")) trimTrailingWhitespace(consequent);
+      this.pos += closeMatch.length;
+      trimAfter = closeMatch.endsWith("-}");
     } else {
       this.throwError(
         'Unclosed if block. Expected "{/if}".',
         "TAU_PARSE_UNCLOSED_BLOCK",
       );
     }
-    return { type: "if", condition, consequent, alternate };
+    return {
+      type: "if",
+      condition,
+      consequent,
+      alternate,
+      trimBefore,
+      trimAfter,
+    };
   }
 
   private parseEachBlock(): Node {
-    this.consume("{#each ");
+    const trimBefore = this.consumeTagPrefix("{#each ");
     const start = this.pos;
     while (this.pos < this.input.length && this.input[this.pos] !== "}") {
       this.pos++;
     }
-    const rawEach = this.input.substring(start, this.pos).trim();
+    const raw = this.input.substring(start, this.pos).trim();
     this.consume("}");
+    const { content: rawEach, trimAfter: trimAfterOpen } = extractTrimSuffix(
+      raw,
+    );
 
     const asIndex = rawEach.indexOf(" as ");
     if (asIndex === -1) {
@@ -327,9 +468,86 @@ export class TauParser {
       );
     }
 
-    const consequent = this.parseBlock(["{/each}"]);
-    this.consume("{/each}");
-    return { type: "each", array, item, indexVar, consequent };
+    const elseVariants = tagVariants("{:else}");
+    const closeVariants = tagVariants("{/each}");
+    const consequent = this.parseBlock([...elseVariants, ...closeVariants]);
+    if (trimAfterOpen) trimLeadingWhitespace(consequent);
+
+    let alternate: Node[] = [];
+    let trimAfter = false;
+
+    const elseMatch = elseVariants.find((v) => this.match(v));
+    if (elseMatch) {
+      if (elseMatch.startsWith("{-")) trimTrailingWhitespace(consequent);
+      this.pos += elseMatch.length;
+      const innerCloseVariants = tagVariants("{/each}");
+      alternate = this.parseBlock(innerCloseVariants);
+      if (elseMatch.endsWith("-}")) trimLeadingWhitespace(alternate);
+      const innerClose = innerCloseVariants.find((v) => this.match(v));
+      if (!innerClose) {
+        this.throwError(
+          'Unclosed each block. Expected "{/each}".',
+          "TAU_PARSE_UNCLOSED_BLOCK",
+        );
+      }
+      if (innerClose.startsWith("{-")) trimTrailingWhitespace(alternate);
+      this.pos += innerClose.length;
+      trimAfter = innerClose.endsWith("-}");
+    } else {
+      const closeMatch = closeVariants.find((v) => this.match(v));
+      if (!closeMatch) {
+        this.throwError(
+          'Unclosed each block. Expected "{/each}".',
+          "TAU_PARSE_UNCLOSED_BLOCK",
+        );
+      }
+      if (closeMatch.startsWith("{-")) trimTrailingWhitespace(consequent);
+      this.pos += closeMatch.length;
+      trimAfter = closeMatch.endsWith("-}");
+    }
+
+    return {
+      type: "each",
+      array,
+      item,
+      indexVar,
+      consequent,
+      alternate,
+      trimBefore,
+      trimAfter,
+    };
+  }
+
+  private parseLetBlock(): Node {
+    this.consume("{#let ");
+    const start = this.pos;
+    while (this.pos < this.input.length && this.input[this.pos] !== "}") {
+      this.pos++;
+    }
+    const raw = this.input.substring(start, this.pos).trim();
+    this.consume("}");
+
+    const eqIndex = raw.indexOf("=");
+    if (eqIndex === -1) {
+      this.throwError(
+        `Invalid let binding syntax: "${raw}". Expected "name = expression".`,
+        "TAU_PARSE_EXPECTED_TOKEN",
+      );
+    }
+    const letName = raw.substring(0, eqIndex).trim();
+    const expression = raw.substring(eqIndex + 1).trim();
+    assertIdentifier(
+      letName,
+      "let binding",
+      (message) => this.throwError(message, "TAU_INVALID_IDENTIFIER"),
+    );
+    if (!expression) {
+      this.throwError(
+        "Let binding expression cannot be empty.",
+        "TAU_PARSE_EMPTY",
+      );
+    }
+    return { type: "let", letName, expression };
   }
 
   private parseIncludeBlock(): Node {
@@ -444,6 +662,7 @@ export class TauParser {
     this.consume("<");
     const start = this.pos;
     let braceCount = 0, inQuotes = false, quoteChar = "";
+    let selfClosing = false;
     while (this.pos < this.input.length) {
       const char = this.input[this.pos];
       if (inQuotes) {
@@ -457,11 +676,23 @@ export class TauParser {
       else if (char === "}") braceCount--;
       else if (
         char === "/" && this.input[this.pos + 1] === ">" && braceCount === 0
-      ) break;
+      ) {
+        selfClosing = true;
+        break;
+      } else if (char === ">" && braceCount === 0) {
+        selfClosing = false;
+        break;
+      }
       this.pos++;
     }
+    if (this.pos >= this.input.length) {
+      this.throwError(
+        'Unclosed component tag. Expected "/>" or ">".',
+        "TAU_PARSE_UNCLOSED_BLOCK",
+      );
+    }
     const componentStr = this.input.substring(start, this.pos).trim();
-    this.consume("/>");
+    this.consume(selfClosing ? "/>" : ">");
 
     const spaceIndex = componentStr.search(/\s/);
     const componentName = spaceIndex !== -1
@@ -476,8 +707,22 @@ export class TauParser {
     const attrString = spaceIndex !== -1
       ? componentStr.substring(spaceIndex).trim()
       : "";
+    const props = parseProps(attrString);
 
-    return { type: "component", componentName, props: parseProps(attrString) };
+    if (selfClosing) {
+      return { type: "component", componentName, props };
+    }
+
+    const closeTag = `</${componentName}>`;
+    const consequent = this.parseBlock([closeTag]);
+    if (!this.match(closeTag)) {
+      this.throwError(
+        `Unclosed component "<${componentName}>". Expected "${closeTag}".`,
+        "TAU_PARSE_UNCLOSED_BLOCK",
+      );
+    }
+    this.consume(closeTag);
+    return { type: "component", componentName, props, consequent };
   }
 
   private parseTextNode(endTags: string[]): Node {
@@ -485,8 +730,9 @@ export class TauParser {
     while (this.pos < this.input.length) {
       if (endTags.some((tag) => this.match(tag))) break;
       if (
-        this.match("{#if ") || this.match("{#each ") || this.match("{@html ") ||
-        this.match("{@include ") ||
+        this.match("{#if ") || this.match("{#each ") || this.match("{#let ") ||
+        this.match("{@html ") || this.match("{@children}") ||
+        this.match("{@include ") || this.matchCommentStart() ||
         (this.peek() === "{" && !["#", "/", ":", "@"].includes(this.peek(1))) ||
         (this.peek() === "<" && /[A-Z]/.test(this.peek(1)))
       ) break;

--- a/src/utils/tau_test.ts
+++ b/src/utils/tau_test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
-import { render } from "./tau.ts";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { filters, render } from "./tau.ts";
 import { formatTauError, TauError } from "./tau_error.ts";
 
 export function registerTauTests(): void {
@@ -16,8 +16,8 @@ export function registerTauTests(): void {
     assertStringIncludes(output, "Hint: Use a registered Tau filter");
   });
 
-  Deno.test("tau: renders expressions and escapes HTML", () => {
-    const output = render({
+  Deno.test("tau: renders expressions and escapes HTML", async () => {
+    const output = await render({
       template: `<p>{ title }</p>`,
       context: { title: `<b>x</b>` },
       components: {},
@@ -26,8 +26,8 @@ export function registerTauTests(): void {
     assertStringIncludes(output, "&lt;b&gt;x&lt;/b&gt;");
   });
 
-  Deno.test("tau: escapes quoted attributes and validates URL schemes", () => {
-    const output = render({
+  Deno.test("tau: escapes quoted attributes and validates URL schemes", async () => {
+    const output = await render({
       template: `<a title="{title}" href="{url | url}">link</a>`,
       context: {
         title: `" onclick="alert(1)`,
@@ -43,7 +43,7 @@ export function registerTauTests(): void {
     for (
       const url of ["javascript:alert(1)", "data:text/html,x", "java\nscript:x"]
     ) {
-      const error = assertThrows(
+      const error = await assertRejects(
         () =>
           render({
             template: `{url | url}`,
@@ -56,9 +56,9 @@ export function registerTauTests(): void {
     }
   });
 
-  Deno.test("tau: raw HTML is explicitly unescaped", () => {
+  Deno.test("tau: raw HTML is explicitly unescaped", async () => {
     assertEquals(
-      render({
+      await render({
         template: `{@html value}`,
         context: { value: `<script>trustedOnly()</script>` },
         components: {},
@@ -67,8 +67,8 @@ export function registerTauTests(): void {
     );
   });
 
-  Deno.test("tau: supports html passthrough and control flow", () => {
-    const output = render({
+  Deno.test("tau: supports html passthrough and control flow", async () => {
+    const output = await render({
       template:
         `{#if show}<ul>{#each tags as tag}<li>{ tag | lower }</li>{/each}</ul>{:else}<p>none</p>{/if}{@html extra}`,
       context: { show: true, tags: ["A", "B"], extra: "<hr>" },
@@ -80,8 +80,8 @@ export function registerTauTests(): void {
     assertStringIncludes(output, "<hr>");
   });
 
-  Deno.test("tau: supports else-if branches", () => {
-    const output = render({
+  Deno.test("tau: supports else-if branches", async () => {
+    const output = await render({
       template: `{#if first}first{:else if second}second{:else}third{/if}`,
       context: { first: false, second: true },
       components: {},
@@ -90,8 +90,8 @@ export function registerTauTests(): void {
     assertEquals(output, "second");
   });
 
-  Deno.test("tau: renders components", () => {
-    const output = render({
+  Deno.test("tau: renders components", async () => {
+    const output = await render({
       template: `<Header title={title} />`,
       context: {
         title: "Hello",
@@ -106,10 +106,10 @@ export function registerTauTests(): void {
     assertEquals(output, "<h1>Hello</h1>");
   });
 
-  Deno.test("tau: parse error includes filePath and line/col in message", () => {
+  Deno.test("tau: parse error includes filePath and line/col in message", async () => {
     // {#each} without "as" keyword triggers a parse error after consuming the block header
     const template = `{#each items}{/each}`;
-    const err = assertThrows(
+    const err = await assertRejects(
       () =>
         render({
           template,
@@ -125,9 +125,9 @@ export function registerTauTests(): void {
     assertStringIncludes(err.message, 'Expected "as" keyword');
   });
 
-  Deno.test("tau: parse error without filePath falls back to Line/col prefix", () => {
+  Deno.test("tau: parse error without filePath falls back to Line/col prefix", async () => {
     const template = `line one\n{#each items}{/each}`;
-    const err = assertThrows(
+    const err = await assertRejects(
       () => render({ template, context: {}, components: {} }),
       Error,
     );
@@ -136,8 +136,8 @@ export function registerTauTests(): void {
     assertStringIncludes(err.message, 'Expected "as" keyword');
   });
 
-  Deno.test("tau: {@include} renders included template via includeResolver", () => {
-    const output = render({
+  Deno.test("tau: {@include} renders included template via includeResolver", async () => {
+    const output = await render({
       template: `<div>{@include "partials/cta.tau"}</div>`,
       context: { title: "Hello" },
       components: {},
@@ -150,8 +150,8 @@ export function registerTauTests(): void {
     assertStringIncludes(output, "<p>Sign up today!</p>");
   });
 
-  Deno.test("tau: {@include} passes context to included template", () => {
-    const output = render({
+  Deno.test("tau: {@include} passes context to included template", async () => {
+    const output = await render({
       template: `{@include "greeting.tau"}`,
       context: { name: "Alice" },
       components: {},
@@ -161,8 +161,8 @@ export function registerTauTests(): void {
     assertStringIncludes(output, "Hello Alice");
   });
 
-  Deno.test("tau: {@include} supports nested includes", () => {
-    const output = render({
+  Deno.test("tau: {@include} supports nested includes", async () => {
+    const output = await render({
       template: `{@include "outer.tau"}`,
       context: {},
       components: {},
@@ -177,8 +177,8 @@ export function registerTauTests(): void {
     assertStringIncludes(output, "inner");
   });
 
-  Deno.test("tau: {@include} throws when no includeResolver provided", () => {
-    assertThrows(
+  Deno.test("tau: {@include} throws when no includeResolver provided", async () => {
+    await assertRejects(
       () =>
         render({
           template: `{@include "missing.tau"}`,
@@ -190,9 +190,9 @@ export function registerTauTests(): void {
     );
   });
 
-  Deno.test("tau: rejects absolute and traversing include paths", () => {
+  Deno.test("tau: rejects absolute and traversing include paths", async () => {
     for (const path of ["../secret.tau", "/secret.tau", "file:///secret.tau"]) {
-      const error = assertThrows(
+      const error = await assertRejects(
         () =>
           render({
             template: `{@include "${path}"}`,
@@ -206,8 +206,8 @@ export function registerTauTests(): void {
     }
   });
 
-  Deno.test("tau: {@include} works alongside components and expressions", () => {
-    const output = render({
+  Deno.test("tau: {@include} works alongside components and expressions", async () => {
+    const output = await render({
       template: `<Header />{@include "body.tau"}{ footer }`,
       context: {
         footer: "bye",
@@ -225,16 +225,20 @@ export function registerTauTests(): void {
     assertStringIncludes(output, "bye");
   });
 
-  Deno.test("tau: blocks ambient runtime and constructor access", () => {
+  Deno.test("tau: blocks ambient runtime and constructor access", async () => {
     for (
       const template of [
         `{ Deno.cwd() }`,
         `{ globalThis }`,
         `{ helpers }`,
         `{ value.constructor.constructor("return 1")() }`,
+        // Dynamic/computed access to a blocked name must be rejected too,
+        // not just the static ".constructor" dot-access form.
+        `{ value["constructor"] }`,
+        `{ value["cons" + "tructor"] }`,
       ]
     ) {
-      assertThrows(
+      await assertRejects(
         () =>
           render({
             template,
@@ -247,7 +251,69 @@ export function registerTauTests(): void {
     }
   });
 
-  Deno.test("tau: rejects code-generating and mutating expressions", () => {
+  Deno.test("tau: supports ternary, optional chaining, and nullish coalescing", async () => {
+    assertEquals(
+      await render({
+        template: `{flag ? "yes" : "no"}`,
+        context: { flag: true },
+        components: {},
+      }),
+      "yes",
+    );
+    assertEquals(
+      await render({
+        template: `{user?.profile?.name}`,
+        context: { user: null },
+        components: {},
+      }),
+      "",
+    );
+    assertEquals(
+      await render({
+        template: `{user?.profile?.name}`,
+        context: { user: { profile: { name: "Ada" } } },
+        components: {},
+      }),
+      "Ada",
+    );
+    assertEquals(
+      await render({
+        template: `{missing ?? "fallback"}`,
+        context: {},
+        components: {},
+      }),
+      "fallback",
+    );
+    assertEquals(
+      await render({
+        template: `{1 + 2 * 3}`,
+        context: {},
+        components: {},
+      }),
+      "7",
+    );
+    assertEquals(
+      await render({
+        template: `{items[0]}`,
+        context: { items: ["first", "second"] },
+        components: {},
+      }),
+      "first",
+    );
+  });
+
+  Deno.test("tau: each-block loop variables can shadow a blocked name", async () => {
+    // Real for-of bindings shadow the blocklist, matching the old
+    // with()-based scoping rules.
+    const output = await render({
+      template: `{#each items as context}{context}{/each}`,
+      context: { items: ["a", "b"] },
+      components: {},
+    });
+    assertEquals(output, "ab");
+  });
+
+  Deno.test("tau: rejects code-generating and mutating expressions", async () => {
     for (
       const template of [
         `{ value = 1 }`,
@@ -256,14 +322,14 @@ export function registerTauTests(): void {
         `{#each items as item);Deno.cwd();//}{/each}`,
       ]
     ) {
-      assertThrows(
+      await assertRejects(
         () => render({ template, context: { value: 0 }, components: {} }),
       );
     }
   });
 
-  Deno.test("tau: rejects prototype-derived filters, components, and props", () => {
-    assertThrows(
+  Deno.test("tau: rejects prototype-derived filters, components, and props", async () => {
+    await assertRejects(
       () =>
         render({
           template: `{value | toString}`,
@@ -273,7 +339,7 @@ export function registerTauTests(): void {
       Error,
       'Unknown Tau filter "toString"',
     );
-    assertThrows(
+    await assertRejects(
       () =>
         render({
           template: `<ToString />`,
@@ -283,7 +349,7 @@ export function registerTauTests(): void {
       Error,
       'Component "ToString" not found',
     );
-    assertThrows(
+    await assertRejects(
       () =>
         render({
           template: `<Card __proto__="x" />`,
@@ -295,8 +361,8 @@ export function registerTauTests(): void {
     );
   });
 
-  Deno.test("tau: detects recursive includes and components", () => {
-    assertThrows(
+  Deno.test("tau: detects recursive includes and components", async () => {
+    await assertRejects(
       () =>
         render({
           template: `{@include "loop.tau"}`,
@@ -308,7 +374,7 @@ export function registerTauTests(): void {
       "include cycle detected",
     );
 
-    assertThrows(
+    await assertRejects(
       () =>
         render({
           template: `<Loop />`,
@@ -320,8 +386,8 @@ export function registerTauTests(): void {
     );
   });
 
-  Deno.test("tau: enforces iteration, output, and template limits", () => {
-    assertThrows(
+  Deno.test("tau: enforces iteration, output, and template limits", async () => {
+    await assertRejects(
       () =>
         render({
           template: `{#each items as item}{item}{/each}`,
@@ -333,7 +399,7 @@ export function registerTauTests(): void {
       "iterations exceed",
     );
 
-    assertThrows(
+    await assertRejects(
       () =>
         render({
           template: `{value}`,
@@ -345,7 +411,7 @@ export function registerTauTests(): void {
       "output exceeds",
     );
 
-    assertThrows(
+    await assertRejects(
       () =>
         render({
           template: "12345",
@@ -358,8 +424,8 @@ export function registerTauTests(): void {
     );
   });
 
-  Deno.test("tau: rejects invalid limits and unclosed if blocks", () => {
-    assertThrows(
+  Deno.test("tau: rejects invalid limits and unclosed if blocks", async () => {
+    await assertRejects(
       () =>
         render({
           template: "ok",
@@ -370,7 +436,7 @@ export function registerTauTests(): void {
       Error,
       'limit "maxDepth"',
     );
-    assertThrows(
+    await assertRejects(
       () =>
         render({
           template: "{#if true}missing close",
@@ -380,5 +446,43 @@ export function registerTauTests(): void {
       Error,
       "Unclosed if block",
     );
+  });
+
+  Deno.test("tau: awaits an async context function without explicit await syntax", async () => {
+    const output = await render({
+      template: `{fetchTitle()}`,
+      context: {
+        fetchTitle: () => Promise.resolve("Async Title"),
+      },
+      components: {},
+    });
+    assertEquals(output, "Async Title");
+  });
+
+  Deno.test("tau: a sync context function still works with the async pipeline", async () => {
+    const output = await render({
+      template: `{greet(name)}`,
+      context: {
+        name: "Ada",
+        greet: (name: string) => `Hello, ${name}!`,
+      },
+      components: {},
+    });
+    assertEquals(output, "Hello, Ada!");
+  });
+
+  Deno.test("tau: an async filter is awaited", async () => {
+    filters.shout = (val: unknown) =>
+      Promise.resolve(`${String(val).toUpperCase()}!`);
+    try {
+      const output = await render({
+        template: `{value | shout}`,
+        context: { value: "hi" },
+        components: {},
+      });
+      assertEquals(output, "HI!");
+    } finally {
+      delete filters.shout;
+    }
   });
 }


### PR DESCRIPTION
Add comments, local bindings, loop else branches, component children,
whitespace control, structured expressions, and async rendering.

BREAKING CHANGE: render(), Theme.renderLayout(), and
Theme.renderComponent() now return Promise<string>. Callers must await
their results.

---

closes #143 