### PR TITLE
refactor: migrate configuration from `custom` to top-level properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@ theme-example
 .DS_Store
 ROADMAP.md
 benchmarks/.bench-history
-steno-website-concept/*
-steno-website-concept

--- a/docs/config_reference.md
+++ b/docs/config_reference.md
@@ -22,16 +22,17 @@ head:
     src: /assets/app.js
     defer: true
 
+theme: ./theme
+themeConfig:
+  accent: purple
+globals:
+  repository: https://example.com/source
+shortUrls: true
+devPort: 5735
+
 custom:
-  theme: ./theme
-  themeConfig:
-    accent: purple
-  globals:
-    repository: https://example.com/source
   stylesheets:
     - /assets/site.css
-  shortUrls: true
-  devPort: 5735
 
 collections:
   posts:
@@ -87,7 +88,7 @@ tag, its `src`. Inline scripts without `src` and link tags without a recognized
 `rel` have no identity and are always appended. A meta entry must set exactly
 one of `name`, `property`, `httpEquiv`, or `charset`.
 
-## `custom`
+## Theme, globals, and other core settings
 
 `theme` accepts a local directory, a local module, or an importable `jsr:`,
 `npm:`, or HTTPS module. `themeConfig` is merged shallowly with theme defaults.
@@ -97,8 +98,18 @@ one of `name`, `property`, `httpEquiv`, or `charset`.
 server port (default 5735). If it is unavailable, Steno scans forward one port
 at a time up to 65535 and binds the first free one.
 
-`stylesheets` is a theme-facing configuration value; Steno exposes it but does
-not inject tags automatically.
+These fields, along with `pluginSourcePolicy` (below), used to live nested under
+a `custom` object. That nesting is deprecated: set them at the top level of the
+config instead. `steno doctor` warns if it finds any of them still under
+`custom`.
+
+## `custom`
+
+`custom` is reserved for free-form, project-specific values that aren't part of
+Steno's own config surface — for example a theme-facing `stylesheets` list that
+Steno exposes but never reads itself. Anything Steno interprets directly
+(`theme`, `themeConfig`, `shortUrls`, `devPort`, `globals`,
+`pluginSourcePolicy`) belongs at the top level, not under `custom`.
 
 ## Plugin source policy
 
@@ -107,20 +118,20 @@ HTTP(S), and `node:` specifiers require an explicit opt-in; `data:` and `blob:`
 are never allowed.
 
 ```yaml
-custom:
-  pluginSourcePolicy:
-    allowLocal: true
-    allowRemoteHttp: false
-    allowNodeBuiltins: false
-    allowThemePlugins: true # default
+pluginSourcePolicy:
+  allowLocal: true
+  allowRemoteHttp: false
+  allowNodeBuiltins: false
+  allowThemePlugins: true # default
 ```
 
 These settings are source filters rather than a runtime sandbox. They do not
 inspect transitive imports or reduce plugin permissions. All configured and
 theme-bundled plugins run in-process with the permissions granted to Steno.
 
-The historical `custom.pluginSecurity` name remains accepted as a deprecated
-compatibility alias. New projects should use `custom.pluginSourcePolicy`.
+The historical `custom.pluginSourcePolicy` and `custom.pluginSecurity` names
+remain accepted as deprecated compatibility aliases. New projects should use
+top-level `pluginSourcePolicy`.
 
 `allowNodeBuiltins` controls only a configured top-level `node:` specifier. It
 cannot prevent a JSR, npm, file, or HTTP(S) plugin from importing a Node

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -15,9 +15,9 @@ project.
   exists; it is created on build either way.
 - **Data directory**: informational. Reports whether `contentDir/_data` exists;
   it is optional.
-- **Theme**: warns if no `custom.theme` is declared, since pages then render as
-  plain HTML with no layout. If the theme is a local path (starts with `.` or
-  `/`), fails when that directory does not exist.
+- **Theme**: warns if no `theme` is declared, since pages then render as plain
+  HTML with no layout. If the theme is a local path (starts with `.` or `/`),
+  fails when that directory does not exist.
 - **Plugins**: reports the declared count, and how many are `isolated` versus
   `trusted`. Trusted plugins produce a warning, since they run in-process with
   Steno's own Deno permissions. Each plugin specifier is checked against the

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -60,13 +60,13 @@ plugin can read or modify project files and generated output without
 restriction. Theme-bundled plugins run at this same trust level unless disabled
 with `allowThemePlugins: false`.
 
-`custom.pluginSourcePolicy` is a top-level module source policy, not an
-execution sandbox — it applies to both modes equally. It does not inspect a
-plugin's transitive imports and cannot prevent an allowed JSR or npm plugin from
+`pluginSourcePolicy` is a top-level module source policy, not an execution
+sandbox — it applies to both modes equally. It does not inspect a plugin's
+transitive imports and cannot prevent an allowed JSR or npm plugin from
 importing another module or a Node built-in.
 
 Only `jsr:` and `npm:` top-level plugin specifiers are allowed by default.
-Enable other sources deliberately under `custom.pluginSourcePolicy`; see
+Enable other sources deliberately under `pluginSourcePolicy`; see
 [Configuration](config_reference.md#plugin-source-policy).
 
 Before adding any plugin or theme, trusted or isolated:

--- a/docs/theme-specification.md
+++ b/docs/theme-specification.md
@@ -19,7 +19,7 @@ export default {
 `name`, `version`, and `layouts` are required. `assets` map output-relative
 paths to strings, `Uint8Array`s, or URLs. Optional `plugins` are trusted,
 in-process code and run with Steno's Deno permissions unless
-`custom.pluginSourcePolicy.allowThemePlugins` is `false`.
+`pluginSourcePolicy.allowThemePlugins` is `false`.
 
 `configSchema` declares `string`, `number`, `integer`, `boolean`, `array`, or
 `object` settings. Fields support `required`, `default`, `description`, and
@@ -27,15 +27,15 @@ in-process code and run with Steno's Deno permissions unless
 `minimum` and `maximum`; arrays support `items`, `minItems`, and `maxItems`;
 objects support nested `properties` and `additionalProperties: false`.
 
-Schema defaults, `defaultConfig`, and site `custom.themeConfig` are applied in
-that order, then validated. The top-level merge is shallow, while schema
-validation and defaults can be recursive. Undeclared top-level keys are allowed
-for backwards compatibility. Invalid values fail theme loading with a path to
-the offending setting.
+Schema defaults, `defaultConfig`, and site `themeConfig` are applied in that
+order, then validated. The top-level merge is shallow, while schema validation
+and defaults can be recursive. Undeclared top-level keys are allowed for
+backwards compatibility. Invalid values fail theme loading with a path to the
+offending setting.
 
 ## Resolution
 
-`custom.theme` accepts, in order of how Steno tries to resolve it:
+`theme` accepts, in order of how Steno tries to resolve it:
 
 1. One of the three bundled theme specifiers, `jsr:@steno/theme-minimal`,
    `jsr:@steno/theme-docs-minimal`, or `jsr:@steno/theme-marketing-minimal`,

--- a/packages/init/src/onboarding.ts
+++ b/packages/init/src/onboarding.ts
@@ -382,10 +382,11 @@ author: ${toYamlString(author)}
 ${toPluginList(plugins)}contentDir: "content"
 output: "dist"
 
-shortUrls: true
-theme: ${toYamlString(themePackage)}
-themeConfig:
-  author: ${toYamlString(author)}
+custom:
+  shortUrls: true
+  theme: ${toYamlString(themePackage)}
+  themeConfig:
+    author: ${toYamlString(author)}
 `,
   );
 

--- a/packages/init/src/onboarding.ts
+++ b/packages/init/src/onboarding.ts
@@ -382,11 +382,10 @@ author: ${toYamlString(author)}
 ${toPluginList(plugins)}contentDir: "content"
 output: "dist"
 
-custom:
-  shortUrls: true
-  theme: ${toYamlString(themePackage)}
-  themeConfig:
-    author: ${toYamlString(author)}
+shortUrls: true
+theme: ${toYamlString(themePackage)}
+themeConfig:
+  author: ${toYamlString(author)}
 `,
   );
 

--- a/packages/theme-docs-minimal/README.md
+++ b/packages/theme-docs-minimal/README.md
@@ -10,24 +10,22 @@ quiet and highly readable.
 To use this theme, specify it in `content/.steno/config.yml`:
 
 ```yaml
-custom:
-  theme: jsr:@steno/theme-docs-minimal@^0.10.0
+theme: jsr:@steno/theme-docs-minimal@^0.10.0
 ```
 
 ## Configuration
 
-All fields are optional strings and can be set under `custom.themeConfig`:
+All fields are optional strings and can be set under `themeConfig`:
 
 ```yaml
-custom:
-  theme: jsr:@steno/theme-docs-minimal@^0.10.0
-  themeConfig:
-    accent: "#7760a9"
-    accentHover: "#5f488f"
-    accentFg: "#ffffff"
-    accentDark: "#9d86d0"
-    accentDarkHover: "#b29ddd"
-    accentDarkFg: "#171519"
+theme: jsr:@steno/theme-docs-minimal@^0.10.0
+themeConfig:
+  accent: "#7760a9"
+  accentHover: "#5f488f"
+  accentFg: "#ffffff"
+  accentDark: "#9d86d0"
+  accentDarkHover: "#b29ddd"
+  accentDarkFg: "#171519"
 ```
 
 `accent`, `accentHover`, and `accentFg` set the light-mode accent color, its

--- a/packages/theme-marketing-minimal/README.md
+++ b/packages/theme-marketing-minimal/README.md
@@ -4,11 +4,10 @@ A polished, content-driven landing-page theme for Steno with responsive product
 sections, code examples, calls to action, and lightweight interactions.
 
 ```yaml
-custom:
-  theme: jsr:@steno/theme-marketing-minimal@^0.10.0
-  themeConfig:
-    githubUrl: https://github.com/your-org/your-project
-    jsrUrl: https://jsr.io/@your-org/your-project
+theme: jsr:@steno/theme-marketing-minimal@^0.10.0
+themeConfig:
+  githubUrl: https://github.com/your-org/your-project
+  jsrUrl: https://jsr.io/@your-org/your-project
 ```
 
 Write landing-page sections directly in Markdown or trusted HTML. The theme
@@ -17,26 +16,25 @@ interaction.
 
 ## Configuration
 
-All fields are optional strings and can be set under `custom.themeConfig`.
+All fields are optional strings and can be set under `themeConfig`.
 
 ```yaml
-custom:
-  themeConfig:
-    accent: "#7760a9"
-    accentHover: "#5f488f"
-    accentFg: "#ffffff"
-    accentDark: "#a994d8"
-    accentDarkHover: "#c0afe6"
-    accentDarkFg: "#171519"
-    eyebrow: "A clearer way forward"
-    heroTitle: "Make the important thing impossible to miss."
-    heroDescription: "A focused, fast landing page for products, studios, and ideas worth sharing."
-    primaryLabel: "Get started"
-    primaryUrl: "#content"
-    secondaryLabel: "Learn more"
-    secondaryUrl: "#content"
-    githubUrl: "https://github.com/stenopress/steno"
-    jsrUrl: "https://jsr.io/@steno/steno"
+themeConfig:
+  accent: "#7760a9"
+  accentHover: "#5f488f"
+  accentFg: "#ffffff"
+  accentDark: "#a994d8"
+  accentDarkHover: "#c0afe6"
+  accentDarkFg: "#171519"
+  eyebrow: "A clearer way forward"
+  heroTitle: "Make the important thing impossible to miss."
+  heroDescription: "A focused, fast landing page for products, studios, and ideas worth sharing."
+  primaryLabel: "Get started"
+  primaryUrl: "#content"
+  secondaryLabel: "Learn more"
+  secondaryUrl: "#content"
+  githubUrl: "https://github.com/stenopress/steno"
+  jsrUrl: "https://jsr.io/@steno/steno"
 ```
 
 `accent`, `accentHover`, and `accentFg` set the light-mode accent color, its

--- a/packages/theme-minimal/README.md
+++ b/packages/theme-minimal/README.md
@@ -7,24 +7,22 @@ A minimal theme for Steno static site generator.
 To use this theme, specify it in `content/.steno/config.yml`:
 
 ```yaml
-custom:
-  theme: jsr:@steno/theme-minimal@^0.10.0
+theme: jsr:@steno/theme-minimal@^0.10.0
 ```
 
 ## Configuration
 
-All fields are optional strings and can be set under `custom.themeConfig`:
+All fields are optional strings and can be set under `themeConfig`:
 
 ```yaml
-custom:
-  theme: jsr:@steno/theme-minimal@^0.10.0
-  themeConfig:
-    accent: "#7760a9"
-    accentHover: "#5f488f"
-    accentFg: "#ffffff"
-    accentDark: "#9d86d0"
-    accentDarkHover: "#b29ddd"
-    accentDarkFg: "#09090b"
+theme: jsr:@steno/theme-minimal@^0.10.0
+themeConfig:
+  accent: "#7760a9"
+  accentHover: "#5f488f"
+  accentFg: "#ffffff"
+  accentDark: "#9d86d0"
+  accentDarkHover: "#b29ddd"
+  accentDarkFg: "#09090b"
 ```
 
 `accent`, `accentHover`, and `accentFg` set the light-mode accent color, its

--- a/src/core/build/build.ts
+++ b/src/core/build/build.ts
@@ -30,6 +30,7 @@ import {
 import { resolvePageConfigOverrides } from "../page_config.ts";
 import { injectHeadTags, mergeHeadTags, validateHeadTags } from "../head.ts";
 import { fileExistsSync as fileExists } from "../../utils/fs.ts";
+import { resolveShortUrls } from "../config.ts";
 
 export type { BuildContext, BuildState, BuildStateEntry } from "./context.ts";
 const STAGING_COPY_CONCURRENCY = 128;
@@ -141,7 +142,7 @@ export async function buildSite({
     const globalVars = resolveConfigGlobals(config);
     const publicEnv = getPublicEnvVars(environment);
     const siteHead = config.head ? validateHeadTags(config.head) : [];
-    const shortUrls = config.custom?.shortUrls ?? false;
+    const shortUrls = resolveShortUrls(config);
     const cachePath = resolveCachePath(contentDir);
     const publicDirPath = resolvePublicDir(contentDir, config.publicDir);
     const publicFiles = publicDirPath

--- a/src/core/build/env.ts
+++ b/src/core/build/env.ts
@@ -1,4 +1,5 @@
 import type { SiteConfig } from "../../types.ts";
+import { resolveGlobals } from "../config.ts";
 
 export function getPublicEnvVars(
   fileValues: Record<string, string> = {},
@@ -21,10 +22,10 @@ export function getPublicEnvVars(
 export function resolveConfigGlobals(
   config: SiteConfig,
 ): Record<string, unknown> {
-  const globals = config.custom?.globals;
+  const globals = resolveGlobals(config);
   if (globals === undefined) return {};
   if (!globals || typeof globals !== "object" || Array.isArray(globals)) {
-    throw new Error("Invalid `custom.globals` in config: expected an object.");
+    throw new Error("Invalid `globals` in config: expected an object.");
   }
   return globals;
 }

--- a/src/core/build/env_test.ts
+++ b/src/core/build/env_test.ts
@@ -85,7 +85,7 @@ Deno.test({
           }),
         ),
       Error,
-      "Invalid `custom.globals`",
+      "Invalid `globals`",
     );
   },
 });
@@ -101,7 +101,7 @@ Deno.test({
           }),
         ),
       Error,
-      "Invalid `custom.globals`",
+      "Invalid `globals`",
     );
   },
 });

--- a/src/core/collections.ts
+++ b/src/core/collections.ts
@@ -9,6 +9,7 @@ import {
   resolveMarkdownScanIgnorePaths,
   resolvePageRoute,
 } from "./path_utils.ts";
+import { resolveShortUrls } from "./config.ts";
 
 /** A page captured as part of a collection. */
 export interface CollectionItem {
@@ -216,7 +217,7 @@ export async function buildCollections(
   } = {},
 ): Promise<CollectionMap> {
   const collections: CollectionMap = {};
-  const shortUrls = config.custom?.shortUrls ?? false;
+  const shortUrls = resolveShortUrls(config);
   const collectionConfigs = config.collections ?? {};
   const markdownPages = pages ?? await collectMarkdownPages(contentDir);
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -8,6 +8,7 @@ import type {
 } from "../types.ts";
 import { isStenoPlugin } from "../plugins/plugins.ts";
 import { loadIsolatedPlugin } from "../plugins/isolated_plugin.ts";
+import { DEFAULT_DEV_PORT } from "../utils/server.ts";
 
 type PluginFactory = (
   options: Record<string, unknown>,
@@ -18,7 +19,8 @@ type ResolvedPluginSourcePolicy = Required<PluginSourcePolicy>;
 export function resolvePluginSourcePolicy(
   config: SiteConfig,
 ): ResolvedPluginSourcePolicy {
-  const policy = config.custom?.pluginSourcePolicy ??
+  const policy = config.pluginSourcePolicy ??
+    config.custom?.pluginSourcePolicy ??
     config.custom?.pluginSecurity ??
     {};
   return {
@@ -27,6 +29,35 @@ export function resolvePluginSourcePolicy(
     allowNodeBuiltins: policy.allowNodeBuiltins === true,
     allowThemePlugins: policy.allowThemePlugins !== false,
   };
+}
+
+/** Resolves the active theme module specifier, preferring top-level `theme`. */
+export function resolveTheme(config: SiteConfig): string | undefined {
+  return config.theme ?? config.custom?.theme;
+}
+
+/** Resolves theme configuration values, preferring top-level `themeConfig`. */
+export function resolveThemeConfig(
+  config: SiteConfig,
+): Record<string, unknown> | undefined {
+  return config.themeConfig ?? config.custom?.themeConfig;
+}
+
+/** Resolves whether directory URLs omit `index.html`. Defaults to `false`. */
+export function resolveShortUrls(config: SiteConfig): boolean {
+  return config.shortUrls ?? config.custom?.shortUrls ?? false;
+}
+
+/** Resolves the development server port. */
+export function resolveDevPort(config: SiteConfig): number {
+  return config.devPort ?? config.custom?.devPort ?? DEFAULT_DEV_PORT;
+}
+
+/** Resolves global values exposed to templates. */
+export function resolveGlobals(
+  config: SiteConfig,
+): Record<string, unknown> | undefined {
+  return config.globals ?? config.custom?.globals;
 }
 
 function getBlockedPluginReason(
@@ -58,16 +89,16 @@ function getBlockedPluginReason(
     case "file:":
       return policy.allowLocal
         ? null
-        : "local `file://` plugin imports are disabled by default. Set `custom.pluginSourcePolicy.allowLocal: true` to allow them.";
+        : "local `file://` plugin imports are disabled by default. Set `pluginSourcePolicy.allowLocal: true` to allow them.";
     case "http:":
     case "https:":
       return policy.allowRemoteHttp
         ? null
-        : "remote `http(s)://` plugin imports are disabled by default. Set `custom.pluginSourcePolicy.allowRemoteHttp: true` to allow them.";
+        : "remote `http(s)://` plugin imports are disabled by default. Set `pluginSourcePolicy.allowRemoteHttp: true` to allow them.";
     case "node:":
       return policy.allowNodeBuiltins
         ? null
-        : "`node:` builtin plugin imports are disabled by default. Set `custom.pluginSourcePolicy.allowNodeBuiltins: true` to allow them.";
+        : "`node:` builtin plugin imports are disabled by default. Set `pluginSourcePolicy.allowNodeBuiltins: true` to allow them.";
     case "data:":
     case "blob:":
       return `\`${url.protocol}\` plugin imports are not allowed.`;

--- a/src/core/config_test.ts
+++ b/src/core/config_test.ts
@@ -1,6 +1,14 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import { join } from "@std/path";
-import { loadConfig, loadPlugins } from "./config.ts";
+import {
+  loadConfig,
+  loadPlugins,
+  resolveDevPort,
+  resolveGlobals,
+  resolveShortUrls,
+  resolveTheme,
+  resolveThemeConfig,
+} from "./config.ts";
 
 export function registerConfigTests(): void {
   Deno.test({
@@ -97,6 +105,99 @@ export function registerConfigTests(): void {
         plugins: [],
       });
       assertEquals(result, []);
+    },
+  });
+
+  const base = { title: "", description: "", author: "" };
+
+  Deno.test({
+    name: "config: resolveTheme prefers top-level over custom.theme",
+    fn: () => {
+      assertEquals(
+        resolveTheme({
+          ...base,
+          theme: "./top",
+          custom: { theme: "./nested" },
+        }),
+        "./top",
+      );
+      assertEquals(
+        resolveTheme({ ...base, custom: { theme: "./nested" } }),
+        "./nested",
+      );
+      assertEquals(resolveTheme(base), undefined);
+    },
+  });
+
+  Deno.test({
+    name:
+      "config: resolveThemeConfig prefers top-level over custom.themeConfig",
+    fn: () => {
+      assertEquals(
+        resolveThemeConfig({
+          ...base,
+          themeConfig: { a: 1 },
+          custom: { themeConfig: { a: 2 } },
+        }),
+        { a: 1 },
+      );
+      assertEquals(
+        resolveThemeConfig({ ...base, custom: { themeConfig: { a: 2 } } }),
+        { a: 2 },
+      );
+    },
+  });
+
+  Deno.test({
+    name: "config: resolveShortUrls prefers top-level, defaults to false",
+    fn: () => {
+      assertEquals(
+        resolveShortUrls({
+          ...base,
+          shortUrls: true,
+          custom: { shortUrls: false },
+        }),
+        true,
+      );
+      assertEquals(
+        resolveShortUrls({ ...base, custom: { shortUrls: true } }),
+        true,
+      );
+      assertEquals(resolveShortUrls(base), false);
+    },
+  });
+
+  Deno.test({
+    name: "config: resolveDevPort prefers top-level, defaults to 5735",
+    fn: () => {
+      assertEquals(
+        resolveDevPort({ ...base, devPort: 4000, custom: { devPort: 5000 } }),
+        4000,
+      );
+      assertEquals(
+        resolveDevPort({ ...base, custom: { devPort: 5000 } }),
+        5000,
+      );
+      assertEquals(resolveDevPort(base), 5735);
+    },
+  });
+
+  Deno.test({
+    name: "config: resolveGlobals prefers top-level over custom.globals",
+    fn: () => {
+      assertEquals(
+        resolveGlobals({
+          ...base,
+          globals: { a: 1 },
+          custom: { globals: { a: 2 } },
+        }),
+        { a: 1 },
+      );
+      assertEquals(
+        resolveGlobals({ ...base, custom: { globals: { a: 2 } } }),
+        { a: 2 },
+      );
+      assertEquals(resolveGlobals(base), undefined);
     },
   });
 }

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -1,4 +1,5 @@
-import { loadConfig, resolvePluginSourcePolicy } from "./config.ts";
+import { resolvePluginSourcePolicy, resolveTheme } from "./config.ts";
+import { resolveProject } from "./project.ts";
 import { join } from "@std/path";
 import { c, fail, info, ok, success, warn } from "../utils/output.ts";
 
@@ -49,21 +50,20 @@ export async function runDoctor(configPath: string): Promise<void> {
     warn(`Deno ${denoVersion} - v2.0.0 or later recommended`);
   }
 
-  // Config file
-  if (!pathIs(configPath, "isFile")) {
-    fail(`Config not found at "${configPath}"`);
-    console.log();
-    console.log(
-      `  ${c.red}Doctor found errors. Fix them and try again.${c.reset}`,
-    );
-    console.log();
-    return;
-  }
-
+  // Config file, or zero-config fallback (single-file/docs discovery) - the
+  // same resolution Steno itself uses to build, so doctor never flags a
+  // project that would actually build fine.
   let config;
   try {
-    config = loadConfig(configPath);
-    ok(`Config found at "${configPath}"`);
+    const project = await resolveProject(configPath);
+    config = project.config;
+    if (project.mode === "configured") {
+      ok(`Config found at "${configPath}"`);
+    } else {
+      ok(
+        `Zero-config mode (${project.mode}) - no "${configPath}" required`,
+      );
+    }
   } catch (e) {
     fail(`Config invalid: ${(e as Error).message}`);
     console.log();
@@ -108,7 +108,7 @@ export async function runDoctor(configPath: string): Promise<void> {
   }
 
   // Theme
-  const themeName = config.custom?.theme;
+  const themeName = resolveTheme(config);
   if (themeName) {
     ok(`Theme declared (${themeName})`);
     // warn on local path themes
@@ -125,6 +125,24 @@ export async function runDoctor(configPath: string): Promise<void> {
     }
   } else {
     warn(`No theme declared - pages will render as plain HTML`);
+  }
+
+  // Deprecated `custom.*` nesting - these fields moved to the top level.
+  const deprecatedCustomKeys: Array<[string, string]> = [
+    ["theme", "theme"],
+    ["themeConfig", "themeConfig"],
+    ["shortUrls", "shortUrls"],
+    ["devPort", "devPort"],
+    ["globals", "globals"],
+    ["pluginSourcePolicy", "pluginSourcePolicy"],
+    ["pluginSecurity", "pluginSourcePolicy"],
+  ];
+  for (const [customKey, topLevelKey] of deprecatedCustomKeys) {
+    if (config.custom?.[customKey] !== undefined) {
+      warn(
+        `custom.${customKey} is deprecated - move it to top-level "${topLevelKey}"`,
+      );
+    }
   }
 
   // Plugins

--- a/src/core/doctor_test.ts
+++ b/src/core/doctor_test.ts
@@ -98,4 +98,125 @@ plugins:
       assertEquals(hintCount, 0);
     },
   });
+
+  Deno.test({
+    name: "doctor: passes on a zero-config project with no config.yml",
+    permissions: { read: true, write: true },
+    fn: async () => {
+      const tempDir = await Deno.makeTempDir();
+      const originalCwd = Deno.cwd();
+      await Deno.mkdir(join(tempDir, "content"), { recursive: true });
+      await Deno.writeTextFile(
+        join(tempDir, "content", "index.md"),
+        "# Home",
+      );
+
+      const messages: string[] = [];
+      const original = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error,
+      };
+      console.log = (...args) => messages.push(args.join(" "));
+      console.warn = (...args) => messages.push(args.join(" "));
+      console.error = (...args) => messages.push(args.join(" "));
+      try {
+        Deno.chdir(tempDir);
+        await runDoctor("content/.steno/config.yml");
+      } finally {
+        Deno.chdir(originalCwd);
+        Object.assign(console, original);
+      }
+
+      const output = messages.join("\n");
+      assertStringIncludes(output, "Zero-config mode");
+      assertEquals(output.includes("Config not found"), false);
+    },
+  });
+
+  Deno.test({
+    name: "doctor: warns when theme/shortUrls remain nested under custom",
+    permissions: { read: true, write: true },
+    fn: async () => {
+      const tempDir = await Deno.makeTempDir();
+      const contentDir = join(tempDir, "content");
+      const outputDir = join(tempDir, "dist");
+      const configPath = join(tempDir, "config.yml");
+      await Deno.mkdir(contentDir);
+      await Deno.writeTextFile(join(contentDir, "index.md"), "# Home");
+      await Deno.writeTextFile(
+        configPath,
+        `contentDir: ${JSON.stringify(contentDir)}
+output: ${JSON.stringify(outputDir)}
+custom:
+  theme: "./theme"
+  shortUrls: true
+`,
+      );
+
+      const messages: string[] = [];
+      const original = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error,
+      };
+      console.log = (...args) => messages.push(args.join(" "));
+      console.warn = (...args) => messages.push(args.join(" "));
+      console.error = (...args) => messages.push(args.join(" "));
+      try {
+        await runDoctor(configPath);
+      } finally {
+        Object.assign(console, original);
+      }
+
+      const output = messages.join("\n");
+      assertStringIncludes(
+        output,
+        'custom.theme is deprecated - move it to top-level "theme"',
+      );
+      assertStringIncludes(
+        output,
+        'custom.shortUrls is deprecated - move it to top-level "shortUrls"',
+      );
+    },
+  });
+
+  Deno.test({
+    name: "doctor: does not warn when theme/shortUrls are top-level",
+    permissions: { read: true, write: true },
+    fn: async () => {
+      const tempDir = await Deno.makeTempDir();
+      const contentDir = join(tempDir, "content");
+      const outputDir = join(tempDir, "dist");
+      const configPath = join(tempDir, "config.yml");
+      await Deno.mkdir(contentDir);
+      await Deno.writeTextFile(join(contentDir, "index.md"), "# Home");
+      await Deno.writeTextFile(
+        configPath,
+        `contentDir: ${JSON.stringify(contentDir)}
+output: ${JSON.stringify(outputDir)}
+theme: "./theme"
+shortUrls: true
+`,
+      );
+
+      const messages: string[] = [];
+      const original = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error,
+      };
+      console.log = (...args) => messages.push(args.join(" "));
+      console.warn = (...args) => messages.push(args.join(" "));
+      console.error = (...args) => messages.push(args.join(" "));
+      try {
+        await runDoctor(configPath);
+      } finally {
+        Object.assign(console, original);
+      }
+
+      const output = messages.join("\n");
+      assertEquals(output.includes("is deprecated"), false);
+    },
+  });
 }

--- a/src/core/project.ts
+++ b/src/core/project.ts
@@ -1,4 +1,4 @@
-import { basename, dirname, isAbsolute, join } from "@std/path";
+import { basename, dirname, isAbsolute, join, relative } from "@std/path";
 import { loadConfig } from "./config.ts";
 import { collectMarkdownPages, type MarkdownPage } from "./collections.ts";
 import type { NavigationNode, SiteConfig } from "../types.ts";
@@ -199,10 +199,22 @@ async function discoverZeroConfigProject(
   }
 
   if (pages.length === 1) {
+    // contentDir becomes the file's own parent directory, which may sit
+    // deeper than scanRootDir (e.g. a lone "content/index.md" at the
+    // project root). relPath was computed against scanRootDir during the
+    // scan above, so it must be recomputed against the reassigned
+    // contentDir or downstream output-path resolution nests an extra
+    // directory into the emitted file (dist/content/index.html instead of
+    // dist/index.html).
+    const contentDir = dirname(pages[0].fullPath);
+    const page = {
+      ...pages[0],
+      relPath: relative(contentDir, pages[0].fullPath),
+    };
     return {
       mode: "single-file",
-      contentDir: dirname(pages[0].fullPath),
-      pages,
+      contentDir,
+      pages: [page],
     };
   }
 
@@ -248,19 +260,17 @@ function buildZeroConfigSiteConfig(
             : join(rootDir, stenoConfig.output.trim()))
           : join(rootDir, "dist"),
       navigation: buildNavigationTree(pages, stenoConfig.shortUrls !== false),
-      custom: {
-        shortUrls: stenoConfig.shortUrls !== false,
-        theme: typeof stenoConfig.theme === "string" &&
-            stenoConfig.theme.trim()
-          ? stenoConfig.theme.trim()
-          : theme,
-        themeConfig: stenoConfig.themeConfig &&
-            typeof stenoConfig.themeConfig === "object" &&
-            stenoConfig.themeConfig !== null &&
-            !Array.isArray(stenoConfig.themeConfig)
-          ? stenoConfig.themeConfig as Record<string, unknown>
-          : {},
-      },
+      shortUrls: stenoConfig.shortUrls !== false,
+      theme: typeof stenoConfig.theme === "string" &&
+          stenoConfig.theme.trim()
+        ? stenoConfig.theme.trim()
+        : theme,
+      themeConfig: stenoConfig.themeConfig &&
+          typeof stenoConfig.themeConfig === "object" &&
+          stenoConfig.themeConfig !== null &&
+          !Array.isArray(stenoConfig.themeConfig)
+        ? stenoConfig.themeConfig as Record<string, unknown>
+        : {},
     };
   }
 
@@ -271,11 +281,9 @@ function buildZeroConfigSiteConfig(
     contentDir: discovery.contentDir,
     output: join(rootDir, "dist"),
     navigation,
-    custom: {
-      shortUrls: true,
-      theme,
-      themeConfig: {},
-    },
+    shortUrls: true,
+    theme,
+    themeConfig: {},
   };
 }
 

--- a/src/core/project_test.ts
+++ b/src/core/project_test.ts
@@ -52,7 +52,7 @@ Plain content.
       const project = await resolveProject(configPath, tempDir);
       assertEquals(project.mode, "single-file");
       assertEquals(project.config.title, "Welcome");
-      assertEquals(project.config.custom?.theme, "jsr:@steno/theme-minimal");
+      assertEquals(project.config.theme, "jsr:@steno/theme-minimal");
       assertEquals(project.pages?.[0].frontmatter.steno, {
         theme: "jsr:@steno/theme-minimal",
       });
@@ -71,6 +71,56 @@ Plain content.
       const html = Deno.readTextFileSync(join(tempDir, "dist", "index.html"));
       assertStringIncludes(html, "<h1>Welcome</h1>");
       assertStringIncludes(html, "Plain content.");
+
+      Deno.removeSync(tempDir, { recursive: true });
+    },
+  });
+
+  Deno.test({
+    name:
+      "zero-config: single-file mode nested in a subdirectory builds to the site root",
+    permissions: { read: true, write: true },
+    fn: async () => {
+      // The README's own quickstart tells users to create "content/index.md"
+      // at the project root. contentDir is reassigned to the file's parent
+      // directory ("content/") in single-file mode, one level deeper than
+      // the scan root - relPath must be recomputed against that, or the
+      // extra directory segment leaks into the output path.
+      const tempDir = Deno.makeTempDirSync();
+      const configPath = join(tempDir, ".steno", "config.yml");
+      const sourcePath = join(tempDir, "content", "index.md");
+
+      Deno.mkdirSync(join(tempDir, "content"), { recursive: true });
+      Deno.writeTextFileSync(
+        sourcePath,
+        `---\ntitle: "Nested"\n---\n# Nested\n`,
+      );
+
+      const project = await resolveProject(configPath, tempDir);
+      assertEquals(project.mode, "single-file");
+      assertEquals(project.config.contentDir, join(tempDir, "content"));
+      assertEquals(project.pages?.[0].relPath, "index.md");
+
+      await buildSite({
+        config: project.config,
+        plugins: [],
+        hooks: {},
+        pages: project.pages,
+      });
+
+      const html = Deno.readTextFileSync(join(tempDir, "dist", "index.html"));
+      assertStringIncludes(html, "<h1>Nested</h1>");
+      assertEquals(
+        (() => {
+          try {
+            Deno.statSync(join(tempDir, "dist", "content", "index.html"));
+            return true;
+          } catch {
+            return false;
+          }
+        })(),
+        false,
+      );
 
       Deno.removeSync(tempDir, { recursive: true });
     },
@@ -103,7 +153,7 @@ Steps.
       const project = await resolveProject(configPath, tempDir);
       assertEquals(project.mode, "docs");
       assertEquals(
-        project.config.custom?.theme,
+        project.config.theme,
         "jsr:@steno/theme-docs-minimal",
       );
       assertEquals(project.config.navigation?.[0].title, "Docs Home");

--- a/src/core/steno.ts
+++ b/src/core/steno.ts
@@ -2,12 +2,12 @@ import type { Theme } from "../theme/theme.ts";
 import type { SiteConfig, StenoHooks, StenoPlugin } from "../types.ts";
 import { isStenoPlugin } from "../plugins/plugins.ts";
 import { disposeIsolatedPlugins } from "../plugins/isolated_plugin.ts";
+import { startDevServer, startPreviewServer } from "../utils/server.ts";
 import {
-  DEFAULT_DEV_PORT,
-  startDevServer,
-  startPreviewServer,
-} from "../utils/server.ts";
-import { loadPlugins, resolvePluginSourcePolicy } from "./config.ts";
+  loadPlugins,
+  resolveDevPort,
+  resolvePluginSourcePolicy,
+} from "./config.ts";
 import { buildSite, type BuildState } from "./build/build.ts";
 import { loadTheme } from "./steno_theme.ts";
 import { type ResolvedProject, resolveProject } from "./project.ts";
@@ -86,7 +86,7 @@ export class Steno {
 
     if (!allowThemePlugins && (this.theme?.plugins?.length ?? 0) > 0) {
       console.warn(
-        "Theme plugins are disabled by `custom.pluginSourcePolicy.allowThemePlugins: false`.",
+        "Theme plugins are disabled by `pluginSourcePolicy.allowThemePlugins: false`.",
       );
     }
 
@@ -133,7 +133,7 @@ export class Steno {
     const project = await this.projectPromise;
     const contentDir = project.config.contentDir || "content";
     const outputDir = project.config.output || "dist";
-    const devPort = project.config.custom?.devPort ?? DEFAULT_DEV_PORT;
+    const devPort = resolveDevPort(project.config);
     const envFiles = getEnvironmentFilePaths(Deno.cwd(), "development").filter(
       (path) => {
         try {

--- a/src/core/steno_theme.ts
+++ b/src/core/steno_theme.ts
@@ -1,6 +1,7 @@
 import { Theme } from "../theme/theme.ts";
 import type { SiteConfig, StenoTheme } from "../types.ts";
 import { fromFileUrl, isAbsolute, join, toFileUrl } from "@std/path";
+import { resolveTheme, resolveThemeConfig } from "./config.ts";
 
 const bundledThemeSources: Record<string, URL> = {
   "jsr:@steno/theme-minimal": new URL(
@@ -51,13 +52,14 @@ async function loadBundledTheme(
 export async function loadTheme(
   config: SiteConfig,
 ): Promise<Theme | undefined> {
-  const themeName = config.custom?.theme;
+  const themeName = resolveTheme(config);
   if (!themeName) return;
+  const themeConfig = resolveThemeConfig(config);
 
   try {
     const bundledTheme = await loadBundledTheme(
       themeName,
-      config.custom?.themeConfig,
+      themeConfig,
     );
     if (bundledTheme) {
       return bundledTheme;
@@ -86,7 +88,7 @@ export async function loadTheme(
       }
 
       if (hasThemeYaml) {
-        return Theme.loadFromDirectory(themeDir, config.custom?.themeConfig);
+        return Theme.loadFromDirectory(themeDir, themeConfig);
       }
 
       let resolvedPath = themeName.startsWith("file://")
@@ -128,12 +130,12 @@ export async function loadTheme(
 
       const themeModule = await import(resolvedPath);
       const themeData = (themeModule.default || themeModule) as StenoTheme;
-      return new Theme(themeData, config.custom?.themeConfig);
+      return new Theme(themeData, themeConfig);
     }
 
     const themeModule = await import(themeName);
     const themeData = (themeModule.default || themeModule) as StenoTheme;
-    return new Theme(themeData, config.custom?.themeConfig);
+    return new Theme(themeData, themeConfig);
   } catch (error) {
     console.error(`Failed to load theme "${themeName}":`, error);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,24 +199,37 @@ export interface SiteConfig {
   collections?: Record<string, CollectionConfig>;
   /** Source-path to destination-path redirect mappings. */
   redirects?: Record<string, string>;
-  /** Steno runtime, theme, and project-specific configuration. */
+  /** Whether directory URLs omit `index.html`. */
+  shortUrls?: boolean;
+  /** Development server port. */
+  devPort?: number;
+  /** Theme module specifier or local path. */
+  theme?: string;
+  /** Values supplied to the active theme. */
+  themeConfig?: Record<string, unknown>;
+  /** Global values exposed to templates. */
+  globals?: Record<string, unknown>;
+  /** Allowed plugin source and execution modes. */
+  pluginSourcePolicy?: PluginSourcePolicy;
+  /** Free-form, project-specific configuration not covered by other fields. */
   custom?: {
     /** Stylesheets injected by the fallback theme. */
     stylesheets?: string[];
-    /** Whether directory URLs omit `index.html`. */
+    /** @deprecated Use top-level `shortUrls` instead. */
     shortUrls?: boolean;
-    /** Development server port. */
+    /** @deprecated Use top-level `devPort` instead. */
     devPort?: number;
-    /** Theme module specifier or local path. */
+    /** @deprecated Use top-level `theme` instead. */
     theme?: string;
-    /** Values supplied to the active theme. */
+    /** @deprecated Use top-level `themeConfig` instead. */
     themeConfig?: Record<string, unknown>;
-    /** Global values exposed to templates. */
+    /** @deprecated Use top-level `globals` instead. */
     globals?: Record<string, unknown>;
-    /** Allowed plugin source and execution modes. */
+    /** @deprecated Use top-level `pluginSourcePolicy` instead. */
     pluginSourcePolicy?: PluginSourcePolicy;
-    /** @deprecated Use `pluginSourcePolicy`. */
+    /** @deprecated Use top-level `pluginSourcePolicy`. */
     pluginSecurity?: PluginSecurityConfig;
+    [key: string]: unknown;
   };
   /** Site-wide navigation tree. */
   navigation?: NavigationNode[];


### PR DESCRIPTION
- Removed deprecated `custom` nesting for theme, themeConfig, shortUrls, devPort, globals, and pluginSourcePolicy in configuration files.
- Updated documentation to reflect the new configuration structure.
- Adjusted related code to resolve values directly from the top-level properties.
- Enhanced `doctor` checks to warn about deprecated `custom` keys.
- Updated tests to ensure proper behavior with the new configuration structure.

---

closes #151