### PR TITLE
fix: checkFrontmatter scaning everything 

### DIFF
--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -2,7 +2,12 @@ import { resolvePluginSourcePolicy, resolveTheme } from "./config.ts";
 import { resolveProject } from "./project.ts";
 import { join } from "@std/path";
 import { c, fail, info, ok, success, warn } from "../utils/output.ts";
-import { STENO_DIR } from "./path_utils.ts";
+import {
+  isPathInsideOrEqual,
+  resolveMarkdownScanIgnorePaths,
+  resolvePublicDir,
+  STENO_DIR,
+} from "./path_utils.ts";
 import { parseFrontmatter } from "../utils/frontmatter.ts";
 import { errorMessage } from "../utils/text.ts";
 
@@ -14,13 +19,20 @@ function pathIs(path: string, type: "isDirectory" | "isFile"): boolean {
   }
 }
 
-function countMarkdownFiles(dir: string): number {
+function isIgnored(path: string, ignorePaths: string[]): boolean {
+  return ignorePaths.some((ignorePath) =>
+    isPathInsideOrEqual(path, ignorePath)
+  );
+}
+
+function countMarkdownFiles(dir: string, ignorePaths: string[]): number {
   let count = 0;
   try {
     for (const entry of Deno.readDirSync(dir)) {
       const fullPath = join(dir, entry.name);
+      if (isIgnored(fullPath, ignorePaths)) continue;
       if (entry.isDirectory && entry.name !== STENO_DIR) {
-        count += countMarkdownFiles(fullPath);
+        count += countMarkdownFiles(fullPath, ignorePaths);
       } else if (entry.isFile && entry.name.endsWith(".md")) {
         count++;
       }
@@ -34,9 +46,11 @@ function countMarkdownFiles(dir: string): number {
 /**
  * Parses every markdown file's frontmatter so a malformed page (bad YAML/
  * TOML indentation, a stray colon) surfaces here instead of deep inside a
- * real build. Returns one message per file that failed to parse.
+ * real build. Skips the same paths `collectMarkdownPages` would (public/,
+ * output/, `.steno/`) so this never flags a file the real build wouldn't
+ * even treat as a page. Returns one message per file that failed to parse.
  */
-function checkFrontmatter(dir: string): string[] {
+function checkFrontmatter(dir: string, ignorePaths: string[]): string[] {
   const errors: string[] = [];
 
   const walk = (currentDir: string) => {
@@ -49,6 +63,7 @@ function checkFrontmatter(dir: string): string[] {
 
     for (const entry of entries) {
       const fullPath = join(currentDir, entry.name);
+      if (isIgnored(fullPath, ignorePaths)) continue;
       if (entry.isDirectory) {
         if (entry.name !== STENO_DIR) walk(fullPath);
       } else if (entry.isFile && entry.name.endsWith(".md")) {
@@ -120,12 +135,20 @@ export async function runDoctor(configPath: string): Promise<void> {
     hasErrors = true;
   }
 
+  // Same paths collectMarkdownPages excludes during a real build, so these
+  // checks never flag a file the build wouldn't treat as a page either.
+  const scanIgnorePaths = resolveMarkdownScanIgnorePaths(
+    contentDir,
+    config.output,
+    resolvePublicDir(contentDir, config.publicDir),
+  );
+
   // Markdown pages
-  const pageCount = countMarkdownFiles(contentDir);
+  const pageCount = countMarkdownFiles(contentDir, scanIgnorePaths);
   if (pageCount > 0) {
     ok(`${pageCount} page${pageCount === 1 ? "" : "s"} found`);
 
-    const frontmatterErrors = checkFrontmatter(contentDir);
+    const frontmatterErrors = checkFrontmatter(contentDir, scanIgnorePaths);
     if (frontmatterErrors.length === 0) {
       ok(
         `Frontmatter parses cleanly in all ${pageCount} page${

--- a/src/core/doctor_test.ts
+++ b/src/core/doctor_test.ts
@@ -219,4 +219,93 @@ shortUrls: true
       assertEquals(output.includes("is deprecated"), false);
     },
   });
+
+  Deno.test({
+    name:
+      "doctor: does not flag malformed frontmatter in public/ (real build never parses it)",
+    permissions: { read: true, write: true },
+    fn: async () => {
+      const tempDir = await Deno.makeTempDir();
+      const contentDir = join(tempDir, "content");
+      const outputDir = join(tempDir, "dist");
+      const configPath = join(tempDir, "config.yml");
+      await Deno.mkdir(contentDir);
+      await Deno.writeTextFile(join(contentDir, "index.md"), "# Home");
+
+      // A raw markdown file meant to be served as-is, not parsed as a page.
+      const publicDir = join(contentDir, "public");
+      await Deno.mkdir(publicDir);
+      await Deno.writeTextFile(
+        join(publicDir, "raw.md"),
+        "---\nnot: [valid\n---\nbroken frontmatter on purpose\n",
+      );
+
+      await Deno.writeTextFile(
+        configPath,
+        `contentDir: ${JSON.stringify(contentDir)}
+output: ${JSON.stringify(outputDir)}
+`,
+      );
+
+      const messages: string[] = [];
+      const original = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error,
+      };
+      console.log = (...args) => messages.push(args.join(" "));
+      console.warn = (...args) => messages.push(args.join(" "));
+      console.error = (...args) => messages.push(args.join(" "));
+      try {
+        await runDoctor(configPath);
+      } finally {
+        Object.assign(console, original);
+      }
+
+      const output = messages.join("\n");
+      assertStringIncludes(output, "Frontmatter parses cleanly");
+      assertEquals(output.includes("raw.md"), false);
+    },
+  });
+
+  Deno.test({
+    name: "doctor: flags malformed frontmatter in an actual content page",
+    permissions: { read: true, write: true },
+    fn: async () => {
+      const tempDir = await Deno.makeTempDir();
+      const contentDir = join(tempDir, "content");
+      const outputDir = join(tempDir, "dist");
+      const configPath = join(tempDir, "config.yml");
+      await Deno.mkdir(contentDir);
+      await Deno.writeTextFile(
+        join(contentDir, "broken.md"),
+        "---\nnot: [valid\n---\nbroken frontmatter on purpose\n",
+      );
+      await Deno.writeTextFile(
+        configPath,
+        `contentDir: ${JSON.stringify(contentDir)}
+output: ${JSON.stringify(outputDir)}
+`,
+      );
+
+      const messages: string[] = [];
+      const original = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error,
+      };
+      console.log = (...args) => messages.push(args.join(" "));
+      console.warn = (...args) => messages.push(args.join(" "));
+      console.error = (...args) => messages.push(args.join(" "));
+      try {
+        await runDoctor(configPath);
+      } finally {
+        Object.assign(console, original);
+      }
+
+      const output = messages.join("\n");
+      assertStringIncludes(output, "broken.md");
+      assertStringIncludes(output, "Doctor found errors");
+    },
+  });
 }


### PR DESCRIPTION
unlike the real build pipeline, which skips public/, output/, and .steno/ via resolveMarkdownScanIgnorePaths

 A markdown file sitting in public/ on purpose (served raw, never meant to be parsed as a page) would false-positive steno doctor into reporting a build-blocking error for a file the real build never even touches.
