### PR TITLE
feat(types): export template context types for theme authors

### DIFF
--- a/docs/theme_development.md
+++ b/docs/theme_development.md
@@ -66,6 +66,9 @@ already has full control over how it builds its own `assets` map. Omit
 Every layout receives `content` (compiled Markdown), `site`, `theme`, `data`,
 `collections`, `env`, `globals`, `assets`, public environment variables, and all
 page frontmatter. `theme` contains its name/version plus merged configuration.
+Writing a TypeScript helper that builds part of this context yourself (outside
+`.tau` templates, which aren't typed)? Import `PageRenderContext` from
+`@steno/steno` for the same shape, with autocomplete.
 
 `assets` maps each theme asset's source-relative path (as written in `assets/`
 or `scripts/`) to its output filename. CSS and JS assets are written under a

--- a/mod.ts
+++ b/mod.ts
@@ -62,7 +62,7 @@ export type {
 } from "./src/types.ts";
 /** Loads and renders theme instances. */
 export { mergeTheme, Theme } from "./src/theme/theme.ts";
-export type { ThemeConfig } from "./src/theme/theme.ts";
+export type { PageRenderContext, ThemeConfig } from "./src/theme/theme.ts";
 
 // Deliberately not `await`-ed at the top level: a top-level await here would
 // keep this module's own evaluation pending for as long as the build runs.

--- a/src/core/build/build.ts
+++ b/src/core/build/build.ts
@@ -1,6 +1,7 @@
 import { join, resolve } from "@std/path";
 import { marked } from "marked";
 import type { CollectionMap } from "../collections.ts";
+import type { PageRenderContext } from "../../theme/theme.ts";
 import { buildCollections, collectMarkdownPages } from "../collections.ts";
 import { runAstTransforms, runHtmlTransforms } from "../../plugins/plugins.ts";
 import { processIncludes } from "../includes.ts";
@@ -386,7 +387,7 @@ export async function buildSite({
           );
         }
 
-        const pageContext = {
+        const pageContext: PageRenderContext = {
           ...pageFrontmatter,
           ...pageGlobals,
           ...publicEnv,
@@ -398,7 +399,9 @@ export async function buildSite({
             : undefined,
           collections: await getCollections(),
           data,
-          title: page.frontmatter.title || page.title || config.title,
+          title: (typeof page.frontmatter.title === "string"
+            ? page.frontmatter.title
+            : undefined) || page.title || config.title,
           assets: themeAssets,
         };
 
@@ -480,7 +483,8 @@ export async function buildSite({
     await mapWithConcurrency(
       renderedWrites,
       STAGING_COPY_CONCURRENCY,
-      (job) => Deno.writeTextFile(job.path, job.content),
+      (job) =>
+        Deno.writeTextFile(job.path, job.content),
     );
     for (
       const { outputFilePath, stagedOutputFilePath, html } of afterPageQueue

--- a/src/core/project_test.ts
+++ b/src/core/project_test.ts
@@ -32,7 +32,12 @@ export function registerProjectTests(): void {
       assertEquals(theme?.config.primaryLabel, "Get started");
       const html = await theme?.renderLayout("layout", "<h2>Details</h2>", {
         title: "Launch",
-        site: { title: "Launch", navigation: [] },
+        site: {
+          title: "Launch",
+          description: "",
+          author: "",
+          navigation: [],
+        },
         theme: { name: theme.name, version: theme.version, ...theme.config },
       });
       assertStringIncludes(html ?? "", 'class="hero"');

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,5 +1,11 @@
 import { render } from "../utils/tau.ts";
-import type { StenoPlugin, StenoTheme, ThemeConfigField } from "../types.ts";
+import type {
+  SiteConfig,
+  StenoPlugin,
+  StenoTheme,
+  ThemeConfigField,
+} from "../types.ts";
+import type { CollectionMap } from "../core/collections.ts";
 import { basename, join, resolve, toFileUrl } from "@std/path";
 import { parse as parseYaml } from "@std/yaml";
 import { transpile } from "@deno/emit";
@@ -9,6 +15,43 @@ import { ensureParentDirSync } from "../utils/fs.ts";
 
 /** Resolved configuration values passed to a theme. */
 export type ThemeConfig = Record<string, unknown>;
+
+/**
+ * The context object a page's layout template renders against — every
+ * field here is reachable in a `.tau` template as `{ field }`. Steno's
+ * own build pipeline always sets these; they're typed optional here so a
+ * hand-built context (tests, a theme's own render helpers) isn't forced
+ * to fabricate every field — Tau templates already guard access with
+ * `{#if theme.accent}`-style checks, so treat these the same way. Page
+ * frontmatter and public env vars are additionally spread in at the top
+ * level, which the index signature covers, since their exact keys vary
+ * per project.
+ *
+ * `content` (the page's rendered HTML body) isn't included here — it's
+ * merged in separately by `Theme.renderLayout`, which is also why this
+ * type covers `renderLayout`'s `variables` parameter rather than the
+ * complete rendered context.
+ */
+export interface PageRenderContext {
+  /** The page's title — frontmatter, inferred from content, or the site title. */
+  title?: string;
+  /** Resolved site config, with any per-page `steno.*` overrides applied. */
+  site?: SiteConfig;
+  /** Values from top-level `globals` and any per-page `steno.globals` override, merged. */
+  globals?: Record<string, unknown>;
+  /** Public (non-secret) environment variables exposed to templates — also spread at the top level. */
+  env?: Record<string, string>;
+  /** Named collections available to templates — see `docs/content.md`. */
+  collections?: CollectionMap;
+  /** Parsed `_data/*` files, keyed by file name. */
+  data?: Record<string, unknown>;
+  /** This theme's name, version, and resolved configuration — `undefined` when the site has no theme. */
+  theme?: { name: string; version: string } & ThemeConfig;
+  /** Each theme asset's original relative path mapped to its (possibly content-hashed) output path. */
+  assets?: Record<string, string>;
+  /** Every other page frontmatter field and public env var, spread at the top level. */
+  [key: string]: unknown;
+}
 
 const ASSET_COPY_CONCURRENCY = 32;
 /** Assets matching this pattern get a content hash baked into their output filename. */
@@ -521,7 +564,7 @@ export class Theme {
   public async renderLayout(
     layoutName: string,
     content: string,
-    variables: Record<string, unknown>,
+    variables: PageRenderContext,
   ): Promise<string> {
     const template = this.themeData.layouts[layoutName];
     if (!template) {

--- a/src/theme/theme_test.ts
+++ b/src/theme/theme_test.ts
@@ -39,8 +39,12 @@ export function registerThemeTests(): void {
 
     const out = await theme.renderLayout("layout", "<p>Body</p>", {
       title: "Post",
-      site: { title: "Site" },
-      theme: { author: "theme-author" },
+      site: { title: "Site", description: "", author: "" },
+      theme: {
+        name: theme.name,
+        version: theme.version,
+        author: "theme-author",
+      },
     });
 
     assertStringIncludes(out, "<h1>Post - Site</h1>");
@@ -133,8 +137,12 @@ export function registerThemeTests(): void {
         author: "override",
       });
       const rendered = await theme.renderLayout("layout", "<p>x</p>", {
-        site: { title: "My Site" },
-        theme: { author: theme.config.author },
+        site: { title: "My Site", description: "", author: "" },
+        theme: {
+          name: theme.name,
+          version: theme.version,
+          author: theme.config.author,
+        },
       });
 
       assertStringIncludes(rendered, "<h1>My Site</h1>");


### PR DESCRIPTION
closes #179

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>