### PR TITLE
docs: freeze public API contracts, tighten MarkdownToken type

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -4,12 +4,28 @@ Most projects never need this page: the `deno x jsr:@steno/steno` CLI covers bui
 and previewing a site. Read this if you're embedding Steno in your own script or tool, writing a
 plugin, or calling `render()` directly instead of through a theme.
 
-The public module is `jsr:@steno/steno` (or this repository's `mod.ts`).
+The public module is `jsr:@steno/steno` (or this repository's `mod.ts`). Every export from `mod.ts`
+is listed on this page - nothing else in the package is public API, even if it happens to be
+reachable by import path.
 
 ```ts
 import { filters, mergeTheme, render, Steno, Theme } from "jsr:@steno/steno";
 import type { SiteConfig, StenoPlugin, StenoTheme } from "jsr:@steno/steno";
 ```
+
+## Stability
+
+- **Stable** - the everyday surface: construction, build/dev/preview, theme and plugin authoring,
+  Tau rendering, and their supporting types. Breaking one of these is a breaking change to Steno
+  itself.
+- **Advanced** - real, supported exports for less common needs (embedding Steno's own CLI, Tau cache
+  introspection). Still covered by the same compatibility promise, just narrower audiences.
+- **Deprecated** - kept for backward compatibility, open-ended (no committed removal version yet).
+  Only `PluginSecurityConfig` (the `custom.pluginSecurity` alias type) is in this tier today; see
+  [Plugin source policy](config_reference.md#plugin-source-policy).
+
+Nothing currently exported from `mod.ts` is internal-only; every export below is one of the first
+two tiers.
 
 ## `Steno`
 
@@ -28,25 +44,38 @@ configuration path is `content/.steno/config.yml`.
 - `cancel()` terminates active isolated-plugin workers. It also runs automatically after every
   `build()` and `dev()` rebuild, so calling it yourself is only needed to stop work early.
 
-`hooks` may provide `beforeBuild`, `afterPage`, and `afterBuild` callbacks; the `SiteConfig` passed
-to `beforeBuild`/`afterBuild` includes a `pages` array (slug, title, description, date) generated
-from the current page set, see [Transactional builds](atomic_builds.md#plugin-and-hook-paths).
+`hooks` may provide `beforeBuild`, `afterPage`, and `afterBuild` callbacks (typed as `StenoHooks`);
+the `SiteConfig` passed to `beforeBuild`/`afterBuild` includes a `pages` array (slug, title,
+description, date) generated from the current page set, see
+[Transactional builds](atomic_builds.md#plugin-and-hook-paths). `afterPage` receives a
+`GeneratedPage` - the staging path (`path`), the file's eventual real location (`finalPath`), and
+its rendered `html`.
+
+**Advanced:** `runStenoCli(args)` runs the same CLI `mod.ts` runs when invoked directly (`build`,
+`dev`, `preview`, `doctor`, `help`), for embedding Steno's own CLI in another tool instead of
+constructing `Steno` yourself.
+
+Errors that fail a production build - a theme, plugin, data file, or redirect that couldn't be
+honored - throw `StenoDiagnosticError`, whose `diagnostics: Diagnostic[]` property carries every
+problem found, not just the first. See
+[How Steno reports problems](troubleshooting.md#how-steno-reports-problems) for the full model
+(severity, and what's fatal in `dev` versus `build`).
 
 ## `Theme`
 
 `new Theme(themeData, userConfig?)` creates a theme from a plain `StenoTheme` object.
 `Theme.loadFromDirectory` loads a convention-based local theme (a folder with `theme.yaml`) instead.
-`renderLayout(name, content, variables)` and `renderComponent(name,
-variables)` render templates and
-return `Promise<string>`. `copyAssets(outputDir, occupiedPaths?, hashAssets?)` writes the theme's
-assets to disk and returns a manifest mapping each asset's source path to its (possibly
-content-hashed) output path; see [Themes and Tau](theme_development.md#layout-context).
+`renderLayout(name, content, variables)` and `renderComponent(name, variables)` render templates and
+return `Promise<string>`; `variables` is the `PageRenderContext` shape (site/theme/page data merged
+for rendering). `copyAssets(outputDir, occupiedPaths?, hashAssets?)` writes the theme's assets to
+disk and returns a manifest mapping each asset's source path to its (possibly content-hashed) output
+path; see [Themes and Tau](theme_development.md#layout-context).
 
 `mergeTheme(base, overrides)` merges a base `StenoTheme` (for example, one of the three official
 themes' exported default) with overrides, producing a new `StenoTheme` for extending a bundled theme
 instead of writing one from scratch. See
 [Extending a bundled theme](theme-specification.md#extending-a-bundled-theme) for the merge rules
-and a full example.
+and a full example. `ThemeConfig` types a theme's resolved, validated configuration object.
 
 ## Tau
 
@@ -58,7 +87,9 @@ when none). `includeResolver` is a caller-supplied `(path: string) => string` fu
 `{@include "path"}` directives to template source; it is required only when a template uses
 `{@include}`, and API consumers rendering templates directly (outside a theme) provide their own.
 `filters` is the mutable null-prototype map of built-in filter functions, enabling applications to
-add filters before rendering.
+add filters before rendering; `FilterFunction` types an entry in that map. `TauOptions` types
+`render()`'s full parameter object; `TauLimits` types its `limits` field (nested render/include
+depth, loop iterations, output size, template size).
 
 Tau failures use `TauError`; its `code` property is a stable `TauErrorCode`, one of
 `TAU_COMPONENT_CYCLE`, `TAU_COMPONENT_NOT_FOUND`, `TAU_INCLUDE_CYCLE`,
@@ -66,18 +97,71 @@ Tau failures use `TauError`; its `code` property is a stable `TauErrorCode`, one
 `TAU_LIMIT_ITERATIONS`, `TAU_LIMIT_OUTPUT`, `TAU_LIMIT_TEMPLATE`, `TAU_PARSE_EMPTY`,
 `TAU_PARSE_EXPECTED_TOKEN`, `TAU_PARSE_INVALID_EACH`, `TAU_PARSE_UNCLOSED_BLOCK`,
 `TAU_RENDER_FAILED`, `TAU_UNKNOWN_FILTER`, `TAU_UNSAFE_EXPRESSION`, `TAU_UNSAFE_INCLUDE_PATH`,
-`TAU_UNSAFE_PROP`, or `TAU_UNSAFE_URL`. `clearTauCache()` releases compiled templates and resets
-counters. `getTauCacheStats()` reports the bounded cache's size, its fixed capacity of 512 compiled
-templates (least-recently-used eviction), hits, misses, and evictions. See the
-[Tau language specification](tau_syntax.md) for grammar, value, escaping, URL, limit, and
-compatibility semantics.
+`TAU_UNSAFE_PROP`, or `TAU_UNSAFE_URL`. Source-backed parse errors also carry a `TauErrorLocation`
+(`filePath`, `line`, `column`). See the [Tau language specification](tau_syntax.md) for grammar,
+value, escaping, URL, limit, and compatibility semantics.
 
-## Types
+**Advanced:** `clearTauCache()` releases compiled templates and resets counters.
+`getTauCacheStats()` reports the bounded cache's size, its fixed capacity of 512 compiled templates
+(least-recently-used eviction), hits, misses, and evictions; `TauCacheStats` types its return value.
 
-Exports include `SiteConfig`, `StenoTheme`, `ThemeConfig`, `StenoPlugin`, `StenoHooks`,
-`PluginEntry`, `PluginSourcePolicy`, the deprecated `PluginSecurityConfig` alias,
-`IsolatedPluginPermissions`, `CollectionConfig`, `NavigationNode`, `HeadTag`, `PageConfigOverrides`,
-`ThemeConfigField`, `MarkdownTokens`, `FilterFunction`, `TauOptions`, `TauLimits`, `TauCacheStats`,
-`TauErrorCode`, `Collection`, `CollectionItem`, and `CollectionMap`, among others. This list isn't
-exhaustive and Steno is still pre-1.0, so treat `mod.ts` itself as the authoritative, up-to-date
-list of what's exported.
+## Collections
+
+A `Collection` (typed `CollectionItem[]` under `name`) groups pages from one `contentDir`
+subdirectory; `CollectionMap` is the full `{ [name]: Collection }` object exposed to templates as
+`collections`. `CollectionConfig` types a `collections.<name>` entry in `SiteConfig` (`sortBy`,
+`order`, `limit`, `filter`, `schema`); `CollectionFieldSchema` types one field of that `schema`. See
+[Collections](content.md#collections).
+
+## Markdown AST transformation (`transformAst`)
+
+A `StenoPlugin`'s `transformAst(tokens)` hook receives - and must return - `marked`'s real lexer
+output, typed as `MarkdownTokens` (a `MarkdownToken[]` plus a `links` map of reference-link
+definitions). `MarkdownToken` only declares the fields every token kind is guaranteed to have
+(`type`, `raw`, optional `text`/`tokens`) - it deliberately doesn't claim you can construct a plain
+`{ type, raw }` object and get correct rendering back. The tokens flow straight into
+`marked.parser()` afterward, which needs each token's real, kind-specific fields (a heading's
+`depth`, a list's `ordered`/`items`, a code block's `lang`, and so on). To read or set those, narrow
+on `type` and cast
+
+- never build a plain object of this shape expecting it to render like a real token.
+
+## Head tags
+
+`HeadTag` is the union of `MetaHeadTag`, `LinkHeadTag`, and `ScriptHeadTag` (all extending the
+common `HeadTagBase`), used for `config.head` and a page's `steno.head` frontmatter override; see
+[Managed head tags](config_reference.md#managed-head-tags).
+
+## Plugin and theme contracts
+
+`StenoPlugin` types a plugin's hook object (`name`, `transformAst`, `transformHtml`, `beforeBuild`,
+`afterPage`, `afterBuild`); `StenoTheme` types a module-based theme's exported shape (`layouts`,
+`components`, `assets`, `configSchema`, `defaultConfig`, optional `plugins`); `PageRenderContext`
+types the object passed into a layout/component render. `StenoHooks` types the `hooks` argument to
+`new Steno(...)`.
+
+`PluginEntry` types a `plugins` array entry in `SiteConfig` (`package`, `options`, `mode`,
+`permissions`, and the isolated-mode fields); `IsolatedPluginPermissions` types its `permissions`
+object; `PluginSourcePolicy` types `config.pluginSourcePolicy`. See
+[Plugins](plugins.md#trust-and-permissions) and [Plugin sandbox](plugin_sandbox.md).
+
+**Deprecated (open-ended):** `PluginSecurityConfig` types the historical `custom.pluginSecurity`
+alias for `pluginSourcePolicy`. It has no committed removal version - it's kept working, just not
+the type to reach for in new code.
+
+## Configuration and navigation
+
+`SiteConfig` types a full, resolved `config.yml`/`config.toml`; see
+[Configuration reference](config_reference.md) for every field and its validated shape.
+`ThemeConfigField` types one entry in a theme's `configSchema`. `NavigationNode` types a
+`config.navigation` (or `steno.navigation` frontmatter) entry (`title`, `url?`, `children?`).
+`PageConfigOverrides` types the resolved shape of a page's `steno.*` frontmatter namespace
+(`title`/`description`/`author`/`head`/`navigation`/`themeConfig`/`globals` overrides).
+
+## Diagnostics
+
+`Diagnostic` types one problem found while resolving a project's theme, plugins, data files,
+redirects, or config (`code`, `severity`, `message`, `file?`, `hint?`). `StenoDiagnosticError` is
+the error a production build throws when any diagnostic is `error`-severity; its `diagnostics`
+property carries all of them. See
+[How Steno reports problems](troubleshooting.md#how-steno-reports-problems).

--- a/src/plugins/plugins_test.ts
+++ b/src/plugins/plugins_test.ts
@@ -1,8 +1,9 @@
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
 import { runAstTransforms, runHtmlTransforms } from "./plugins.ts";
 import { loadPlugins } from "../core/config.ts";
 import type { StenoPlugin } from "./plugins.ts";
+import type { MarkdownTokens } from "../types.ts";
 import { marked } from "marked";
 
 export function registerPluginTests(): void {
@@ -12,6 +13,41 @@ export function registerPluginTests(): void {
     const tokens = marked.lexer("# Hello");
     const result = await runAstTransforms(tokens, []);
     assertEquals(result, tokens);
+  });
+
+  Deno.test("plugins: MarkdownTokens is compile-time compatible with marked.lexer()'s real output", async () => {
+    // This assignment is itself the compatibility check: if marked's Token
+    // shape ever drops `type`/`raw`/`links`, this file fails to type-check
+    // in CI - see MarkdownToken's docs in types.ts for why the public type
+    // stays this minimal on purpose.
+    const source =
+      "# Heading\n\nA paragraph with a [link](https://example.com).\n\n- one\n- two\n\n```ts\nconst x = 1;\n```\n";
+    const tokens: MarkdownTokens = marked.lexer(source);
+
+    for (const token of tokens) {
+      assertEquals(typeof token.type, "string");
+      assertEquals(typeof token.raw, "string");
+    }
+
+    // The same tokens, unmodified, must still render correctly through
+    // marked.parser() after a round trip through a transformAst plugin -
+    // proving real (not minimal) token fidelity survives the hook.
+    let sawTokens: MarkdownTokens | undefined;
+    const identityPlugin: StenoPlugin = {
+      name: "identity",
+      transformAst: (t) => {
+        sawTokens = t;
+        return t;
+      },
+    };
+    const result = await runAstTransforms(tokens, [identityPlugin]);
+    assertEquals(sawTokens, tokens);
+
+    const html = marked.parser(result);
+    assertStringIncludes(html, "<h1>Heading</h1>");
+    assertStringIncludes(html, '<a href="https://example.com">link</a>');
+    assertStringIncludes(html, "<li>one</li>");
+    assertStringIncludes(html, "const x = 1;");
   });
 
   Deno.test("plugins: runAstTransforms runs transforms in order", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -314,12 +314,22 @@ export interface ThemeConfigField {
 /**
  * A Markdown AST token exposed to transformation plugins.
  *
- * Token-specific fields remain available by narrowing or casting the value.
+ * At runtime, `transformAst` receives - and must return - `marked`'s actual
+ * `Token` objects (from `marked.lexer()`), not plain objects shaped like
+ * this interface. `MarkdownToken` declares only the fields every token kind
+ * is guaranteed to have, so it's independent of `marked`'s own exported type
+ * names; it deliberately does **not** claim you can construct a minimal
+ * `{ type, raw }` object and hand it back; the tokens flow straight into
+ * `marked.parser()` afterward, which needs each token's real, kind-specific
+ * fields (a heading's `depth`, a list's `ordered`/`items`, a code block's
+ * `lang`, and so on) to render correctly. To read or set those, narrow on
+ * `type` and cast (`token as unknown as SomeMarkedTokenShape`) - never
+ * construct a plain object of this shape and expect full rendering from it.
  */
 export interface MarkdownToken {
-  /** Token kind, such as `heading`, `paragraph`, or `text`. */
+  /** Token kind, such as `heading`, `paragraph`, or `text`. Always present. */
   type: string;
-  /** Original Markdown source represented by the token. */
+  /** Original Markdown source represented by the token. Always present. */
   raw: string;
   /** Plain-text token content when the token kind provides it. */
   text?: string;
@@ -327,7 +337,12 @@ export interface MarkdownToken {
   tokens?: MarkdownToken[];
 }
 
-/** Markdown token list accepted and returned by AST transformation hooks. */
+/**
+ * Markdown token list accepted and returned by AST transformation hooks -
+ * the exact value `marked.lexer()` produces, typed as `MarkdownToken[]` plus
+ * its `links` property. See {@link MarkdownToken} for what that means for a
+ * `transformAst` implementation.
+ */
 export interface MarkdownTokens extends Array<MarkdownToken> {
   /** Reference-link definitions collected while lexing Markdown. */
   links: Record<string, {


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>