### PR TITLE
refactor(init): extract terminal utilities

### DIFF
--- a/packages/init/deno.json
+++ b/packages/init/deno.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "tasks": {
-    "test": "deno test -A ./test.ts ./scaffold_test.ts",
+    "test": "deno test -A ./test.ts ./scaffold_test.ts ./src/terminal_test.ts",
     "test:smoke": "deno test -A ./smoke_test.ts"
   },
   "imports": {

--- a/packages/init/src/onboarding.ts
+++ b/packages/init/src/onboarding.ts
@@ -8,6 +8,20 @@
  */
 
 import { join } from "@std/path";
+import {
+  c,
+  ESC,
+  heading,
+  isInteractiveTerminal,
+  paint,
+  printBanner,
+  readKey,
+  setRawMode,
+  truncate,
+  writeTerminal,
+} from "./terminal.ts";
+
+export { c, heading, paint } from "./terminal.ts";
 
 /** Options that can be passed directly to {@link runOnboarding}. When a field
  * is omitted the user is prompted interactively. */
@@ -154,94 +168,6 @@ export class OnboardingError extends Error {
   }
 }
 
-const ESC = "\x1b[";
-
-function noColorRequested(): boolean {
-  try {
-    return Deno.env.get("NO_COLOR") !== undefined;
-  } catch {
-    return false;
-  }
-}
-
-const useColor = !noColorRequested();
-const color = (code: string): string => (useColor ? `${ESC}${code}m` : "");
-
-/** Shared color codes, exported so other scaffolders (theme/plugin) match this CLI's look. */
-export const c = {
-  reset: color("0"),
-  bold: color("1"),
-  dim: color("2"),
-  purple: color("38;5;135"),
-  purpleBold: color("1;38;5;135"),
-  white: color("97"),
-  whiteBold: color("1;97"),
-  gray: color("38;5;245"),
-  green: color("38;5;120"),
-  yellow: color("38;5;222"),
-  cyan: color("38;5;159"),
-  cyanBold: color("1;38;5;159"),
-};
-
-/** Wraps `text` in `color`, resetting afterward. */
-export function paint(color: string, text: string): string {
-  return `${color}${text}${c.reset}`;
-}
-
-function printBanner(): void {
-  const logo = [
-    `   \x1b[32mTTTTT\x1b[0m    \x1b[31mNNNN\x1b[0m`,
-    ` \x1b[35mSSS\x1b[0m \x1b[32mT\x1b[0m \x1b[33mEEEE\x1b[0m \x1b[31mN  N\x1b[0m \x1b[34mOOOO\x1b[0m`,
-    `\x1b[35mS\x1b[0m    \x1b[32mT\x1b[0m \x1b[33mE\x1b[0m    \x1b[31mN  N\x1b[0m \x1b[34mO  O\x1b[0m`,
-    ` \x1b[35mSS\x1b[0m  \x1b[32mT\x1b[0m \x1b[33mEEE\x1b[0m  \x1b[31mN  N\x1b[0m \x1b[34mO  O\x1b[0m`,
-    `   \x1b[35mS\x1b[0m \x1b[32mT\x1b[0m \x1b[33mE\x1b[0m    \x1b[31mN  N\x1b[0m \x1b[34mO  O\x1b[0m`,
-    `\x1b[35mSSS\x1b[0m    \x1b[33mEEEE\x1b[0m      \x1b[34mOOOO\x1b[0m`,
-  ];
-
-  const stripAnsi = (s: string) => s.replace(new RegExp(`${ESC}[0-9;]*m`, "g"), "");
-  const logoWidth = Math.max(...logo.map((l) => stripAnsi(l).length));
-
-  const tagline = "A fast Deno-powered static site generator";
-  const words = tagline.split(" ");
-  const lines: string[] = [];
-  let current = "";
-
-  for (const word of words) {
-    const next = current ? `${current} ${word}` : word;
-    if (next.length <= logoWidth) {
-      current = next;
-    } else {
-      if (current) lines.push(current);
-      current = word;
-    }
-  }
-  if (current) lines.push(current);
-
-  const termWidth = (() => {
-    try {
-      return Deno.consoleSize().columns;
-    } catch {
-      return 80;
-    }
-  })();
-  const leftPad = Math.floor((termWidth - logoWidth) / 2);
-  const p = " ".repeat(leftPad);
-
-  for (const line of logo) console.log(p + (useColor ? line : stripAnsi(line)));
-  console.log();
-  for (const line of lines) {
-    const pad = Math.floor((logoWidth - line.length) / 2);
-    console.log(paint(c.gray, p + " ".repeat(pad) + line));
-  }
-  console.log();
-}
-
-/** Prints a section header matching this CLI's onboarding output. */
-export function heading(text: string): void {
-  console.log(`\n${paint(c.purpleBold, "◆")} ${paint(c.whiteBold, text)}`);
-  console.log(paint(c.gray, "  " + "─".repeat(text.length + 2)));
-}
-
 function toYamlString(value: string): string {
   return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
 }
@@ -346,62 +272,6 @@ function selectTheme(advanced: boolean): string {
   }
 }
 
-function isInteractiveTerminal(): boolean {
-  try {
-    return Deno.stdin.isTerminal() && Deno.stdout.isTerminal();
-  } catch {
-    return false;
-  }
-}
-
-function setRawMode(enabled: boolean): void {
-  try {
-    Deno.stdin.setRaw(enabled);
-  } catch {
-    // stdin is not a tty; caller should have already checked isInteractiveTerminal.
-  }
-}
-
-const encoder = new TextEncoder();
-const write = (text: string): void => {
-  Deno.stdout.writeSync(encoder.encode(text));
-};
-
-type Key = "up" | "down" | "space" | "enter" | "cancel" | "unknown";
-
-function readKey(): Key {
-  const buf = new Uint8Array(8);
-  const n = Deno.stdin.readSync(buf);
-  if (n === null || n === 0) return "unknown";
-  const bytes = buf.subarray(0, n);
-
-  if (bytes.length === 1) {
-    switch (bytes[0]) {
-      case 3: // Ctrl+C
-        return "cancel";
-      case 13: // Enter
-      case 10:
-        return "enter";
-      case 32: // Space
-        return "space";
-    }
-  }
-
-  if (bytes.length >= 3 && bytes[0] === 27 && bytes[1] === 91) {
-    if (bytes[2] === 65) return "up"; // ESC [ A
-    if (bytes[2] === 66) return "down"; // ESC [ B
-  }
-
-  if (bytes[0] === 27) return "cancel"; // plain Escape
-
-  return "unknown";
-}
-
-function truncate(text: string, maxLength: number): string {
-  if (maxLength <= 1 || text.length <= maxLength) return text;
-  return text.slice(0, Math.max(0, maxLength - 1)).trimEnd() + "…";
-}
-
 function promptPackageSpecifier(): string | undefined {
   const arrow = paint(c.purple, "›");
   const value = prompt(
@@ -487,14 +357,14 @@ function selectPluginsInteractive(): PluginSelection {
   let lastRowCount = 0;
   const render = (first: boolean): void => {
     const rows = buildRows();
-    if (!first) write(`${ESC}${lastRowCount}A`);
+    if (!first) writeTerminal(`${ESC}${lastRowCount}A`);
     for (let i = 0; i < rows.length; i++) {
-      write(`\r${ESC}2K${renderRow(rows[i], i === cursor)}\n`);
+      writeTerminal(`\r${ESC}2K${renderRow(rows[i], i === cursor)}\n`);
     }
     lastRowCount = rows.length;
   };
 
-  write(`${ESC}?25l`); // hide cursor
+  writeTerminal(`${ESC}?25l`); // hide cursor
   setRawMode(true);
 
   try {
@@ -525,10 +395,10 @@ function selectPluginsInteractive(): PluginSelection {
         const row = rows[cursor];
         if (row.type === "add-community") {
           setRawMode(false);
-          write(`${ESC}?25h`);
+          writeTerminal(`${ESC}?25h`);
           const pkg = promptPackageSpecifier();
           setRawMode(true);
-          write(`${ESC}?25l`);
+          writeTerminal(`${ESC}?25l`);
           if (pkg) {
             communityPackages.push(pkg);
             selectedCommunity.add(communityPackages.length - 1);
@@ -540,14 +410,14 @@ function selectPluginsInteractive(): PluginSelection {
         }
       } else if (key === "cancel") {
         setRawMode(false);
-        write(`${ESC}?25h`);
+        writeTerminal(`${ESC}?25h`);
         console.log();
         Deno.exit(130);
       }
     }
   } finally {
     setRawMode(false);
-    write(`${ESC}?25h`);
+    writeTerminal(`${ESC}?25h`);
   }
 
   console.log();

--- a/packages/init/src/terminal.ts
+++ b/packages/init/src/terminal.ts
@@ -1,0 +1,139 @@
+const ESC = "\x1b[";
+
+function noColorRequested(): boolean {
+  try {
+    return Deno.env.get("NO_COLOR") !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+const useColor = !noColorRequested();
+const color = (code: string): string => (useColor ? `${ESC}${code}m` : "");
+
+/** Shared color codes used by the init scaffolders. */
+export const c = {
+  reset: color("0"),
+  bold: color("1"),
+  dim: color("2"),
+  purple: color("38;5;135"),
+  purpleBold: color("1;38;5;135"),
+  white: color("97"),
+  whiteBold: color("1;97"),
+  gray: color("38;5;245"),
+  green: color("38;5;120"),
+  yellow: color("38;5;222"),
+  cyan: color("38;5;159"),
+  cyanBold: color("1;38;5;159"),
+};
+
+/** Wraps text in a terminal color and resets the color afterward. */
+export function paint(terminalColor: string, text: string): string {
+  return `${terminalColor}${text}${c.reset}`;
+}
+
+function stripAnsi(text: string): string {
+  return text.replace(new RegExp(`${ESC}[0-9;]*m`, "g"), "");
+}
+
+function terminalWidth(): number {
+  try {
+    return Deno.consoleSize().columns;
+  } catch {
+    return 80;
+  }
+}
+
+function wrapText(text: string, width: number): string[] {
+  const lines: string[] = [];
+  let current = "";
+  for (const word of text.split(" ")) {
+    const next = current ? `${current} ${word}` : word;
+    if (next.length <= width) current = next;
+    else {
+      if (current) lines.push(current);
+      current = word;
+    }
+  }
+  if (current) lines.push(current);
+  return lines;
+}
+
+export function printBanner(): void {
+  const logo = [
+    `   \x1b[32mTTTTT\x1b[0m    \x1b[31mNNNN\x1b[0m`,
+    ` \x1b[35mSSS\x1b[0m \x1b[32mT\x1b[0m \x1b[33mEEEE\x1b[0m \x1b[31mN  N\x1b[0m \x1b[34mOOOO\x1b[0m`,
+    `\x1b[35mS\x1b[0m    \x1b[32mT\x1b[0m \x1b[33mE\x1b[0m    \x1b[31mN  N\x1b[0m \x1b[34mO  O\x1b[0m`,
+    ` \x1b[35mSS\x1b[0m  \x1b[32mT\x1b[0m \x1b[33mEEE\x1b[0m  \x1b[31mN  N\x1b[0m \x1b[34mO  O\x1b[0m`,
+    `   \x1b[35mS\x1b[0m \x1b[32mT\x1b[0m \x1b[33mE\x1b[0m    \x1b[31mN  N\x1b[0m \x1b[34mO  O\x1b[0m`,
+    `\x1b[35mSSS\x1b[0m    \x1b[33mEEEE\x1b[0m      \x1b[34mOOOO\x1b[0m`,
+  ];
+  const logoWidth = Math.max(...logo.map((line) => stripAnsi(line).length));
+  const lines = wrapText("A fast Deno-powered static site generator", logoWidth);
+  const leftPad = Math.max(0, Math.floor((terminalWidth() - logoWidth) / 2));
+  const prefix = " ".repeat(leftPad);
+
+  for (const line of logo) console.log(prefix + (useColor ? line : stripAnsi(line)));
+  console.log();
+  for (const line of lines) {
+    const pad = Math.floor((logoWidth - line.length) / 2);
+    console.log(paint(c.gray, prefix + " ".repeat(pad) + line));
+  }
+  console.log();
+}
+
+/** Prints a section header matching the onboarding output. */
+export function heading(text: string): void {
+  console.log(`\n${paint(c.purpleBold, "◆")} ${paint(c.whiteBold, text)}`);
+  console.log(paint(c.gray, "  " + "─".repeat(text.length + 2)));
+}
+
+export function isInteractiveTerminal(): boolean {
+  try {
+    return Deno.stdin.isTerminal() && Deno.stdout.isTerminal();
+  } catch {
+    return false;
+  }
+}
+
+export function setRawMode(enabled: boolean): void {
+  try {
+    Deno.stdin.setRaw(enabled);
+  } catch {
+    // A non-interactive stdin cannot enter raw mode.
+  }
+}
+
+const encoder = new TextEncoder();
+
+export function writeTerminal(text: string): void {
+  Deno.stdout.writeSync(encoder.encode(text));
+}
+
+export type Key = "up" | "down" | "space" | "enter" | "cancel" | "unknown";
+
+export function decodeKey(bytes: Uint8Array): Key {
+  if (bytes.length === 1) {
+    if (bytes[0] === 3 || bytes[0] === 27) return "cancel";
+    if (bytes[0] === 13 || bytes[0] === 10) return "enter";
+    if (bytes[0] === 32) return "space";
+  }
+  if (bytes.length >= 3 && bytes[0] === 27 && bytes[1] === 91) {
+    if (bytes[2] === 65) return "up";
+    if (bytes[2] === 66) return "down";
+  }
+  return "unknown";
+}
+
+export function readKey(): Key {
+  const buffer = new Uint8Array(8);
+  const bytesRead = Deno.stdin.readSync(buffer);
+  return bytesRead ? decodeKey(buffer.subarray(0, bytesRead)) : "unknown";
+}
+
+export function truncate(text: string, maxLength: number): string {
+  if (maxLength <= 1 || text.length <= maxLength) return text;
+  return text.slice(0, Math.max(0, maxLength - 1)).trimEnd() + "…";
+}
+
+export { ESC };

--- a/packages/init/src/terminal_test.ts
+++ b/packages/init/src/terminal_test.ts
@@ -1,0 +1,20 @@
+import { assertEquals } from "@std/assert";
+import { decodeKey, truncate } from "./terminal.ts";
+
+Deno.test("terminal: decodes interactive keys", () => {
+  assertEquals(decodeKey(new Uint8Array([27, 91, 65])), "up");
+  assertEquals(decodeKey(new Uint8Array([27, 91, 66])), "down");
+  assertEquals(decodeKey(new Uint8Array([32])), "space");
+  assertEquals(decodeKey(new Uint8Array([13])), "enter");
+  assertEquals(decodeKey(new Uint8Array([10])), "enter");
+  assertEquals(decodeKey(new Uint8Array([3])), "cancel");
+  assertEquals(decodeKey(new Uint8Array([27])), "cancel");
+  assertEquals(decodeKey(new Uint8Array([120])), "unknown");
+  assertEquals(decodeKey(new Uint8Array()), "unknown");
+});
+
+Deno.test("terminal: truncates only when text exceeds the limit", () => {
+  assertEquals(truncate("short", 10), "short");
+  assertEquals(truncate("long description", 8), "long de…");
+  assertEquals(truncate("anything", 1), "anything");
+});


### PR DESCRIPTION
## Summary

- extract terminal colors, banner rendering, TTY detection, raw mode, key reading, and truncation from onboarding orchestration
- preserve the existing `c`, `paint`, and `heading` re-exports
- add direct tests for key decoding and truncation

## Verification

- 33 init package tests
- generated-project smoke test across all official themes
- lint and formatting checks

Stack: bottom layer; prompt extraction will follow.