### PR TITLE
feat(perf): guard benchmark trends

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ the test environment, averages, and tail latency instead of presenting one resul
 deno task bench
 deno task bench:check
 deno task bench:report
+deno task bench:trends
 ```
 
 ## CLI

--- a/benchmarks/bench_trends.ts
+++ b/benchmarks/bench_trends.ts
@@ -1,16 +1,27 @@
 import { join } from "@std/path";
 import { formatNs, getMetrics, readOrRunBenchmarks } from "./bench_results.ts";
-
-interface BenchSnapshot {
-  timestamp: string;
-  benches: Array<{ name: string; avgNs: number; p99Ns: number }>;
-}
+import {
+  type BenchSnapshot,
+  compareBenchSnapshots,
+  parseRegressionThreshold,
+} from "./bench_trends_core.ts";
 
 const HISTORY_DIR = join(Deno.cwd(), "benchmarks", ".bench-history");
 const LATEST_FILE = join(HISTORY_DIR, "latest.json");
 const HISTORY_FILE = join(HISTORY_DIR, "history.ndjson");
+const TREND_THRESHOLD_ENV = "STENO_BENCH_TREND_THRESHOLD";
+
+async function readLatestSnapshot(): Promise<BenchSnapshot | undefined> {
+  try {
+    return JSON.parse(await Deno.readTextFile(LATEST_FILE)) as BenchSnapshot;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return;
+    throw error;
+  }
+}
 
 const output = await readOrRunBenchmarks(Deno.args[0]);
+const previous = await readLatestSnapshot();
 const snapshot: BenchSnapshot = {
   timestamp: new Date().toISOString(),
   benches: (output.benches ?? [])
@@ -27,15 +38,41 @@ const snapshot: BenchSnapshot = {
 };
 
 await Deno.mkdir(HISTORY_DIR, { recursive: true });
-await Deno.writeTextFile(LATEST_FILE, JSON.stringify(snapshot, null, 2));
 await Deno.writeTextFile(HISTORY_FILE, JSON.stringify(snapshot) + "\n", {
   append: true,
   create: true,
 });
 
-const top = [...snapshot.benches].sort((a, b) => b.avgNs - a.avgNs).slice(0, 10);
-
-console.log(`Stored benchmark snapshot at ${LATEST_FILE}`);
-for (const bench of top) {
-  console.log(`${bench.name}: avg=${formatNs(bench.avgNs)} p99=${formatNs(bench.p99Ns)}`);
+if (!previous) {
+  await Deno.writeTextFile(LATEST_FILE, JSON.stringify(snapshot, null, 2));
+  console.log(`Stored initial benchmark baseline at ${LATEST_FILE}`);
+  Deno.exit(0);
 }
+
+const threshold = parseRegressionThreshold(Deno.env.get(TREND_THRESHOLD_ENV));
+const evaluation = compareBenchSnapshots(previous, snapshot, threshold);
+for (const comparison of evaluation.comparisons) {
+  const change = `${comparison.changeRatio >= 0 ? "+" : ""}${(comparison.changeRatio * 100).toFixed(
+    1,
+  )}%`;
+  console.log(
+    `${comparison.name}: ${formatNs(comparison.previousAvgNs)} -> ${formatNs(
+      comparison.currentAvgNs,
+    )} (${change})`,
+  );
+}
+for (const name of evaluation.added) console.log(`${name}: new benchmark`);
+for (const name of evaluation.missing) console.warn(`${name}: missing from current run`);
+
+if (evaluation.failures.length > 0) {
+  for (const failure of evaluation.failures) {
+    console.error(
+      `TREND FAIL: ${failure.name} regressed ${(failure.changeRatio * 100).toFixed(1)}% ` +
+        `(limit ${(threshold * 100).toFixed(1)}%)`,
+    );
+  }
+  Deno.exit(1);
+}
+
+await Deno.writeTextFile(LATEST_FILE, JSON.stringify(snapshot, null, 2));
+console.log(`Updated accepted benchmark baseline at ${LATEST_FILE}`);

--- a/benchmarks/bench_trends_core.ts
+++ b/benchmarks/bench_trends_core.ts
@@ -1,0 +1,68 @@
+export interface BenchSnapshot {
+  timestamp: string;
+  benches: Array<{ name: string; avgNs: number; p99Ns: number }>;
+}
+
+export interface TrendComparison {
+  name: string;
+  previousAvgNs: number;
+  currentAvgNs: number;
+  changeRatio: number;
+}
+
+export interface TrendEvaluation {
+  comparisons: TrendComparison[];
+  failures: TrendComparison[];
+  added: string[];
+  missing: string[];
+}
+
+export function parseRegressionThreshold(raw: string | undefined): number {
+  if (raw === undefined) return 0.2;
+
+  const threshold = Number(raw);
+  if (!Number.isFinite(threshold) || threshold < 0) {
+    throw new Error(`Benchmark trend threshold must be a non-negative number, received "${raw}".`);
+  }
+  return threshold;
+}
+
+export function compareBenchSnapshots(
+  previous: BenchSnapshot,
+  current: BenchSnapshot,
+  threshold = 0.2,
+): TrendEvaluation {
+  const previousByName = new Map(previous.benches.map((bench) => [bench.name, bench]));
+  const currentNames = new Set(current.benches.map((bench) => bench.name));
+  const comparisons: TrendComparison[] = [];
+  const added: string[] = [];
+
+  for (const bench of current.benches) {
+    const baseline = previousByName.get(bench.name);
+    if (!baseline) {
+      added.push(bench.name);
+      continue;
+    }
+    const changeRatio =
+      baseline.avgNs === 0
+        ? bench.avgNs === 0
+          ? 0
+          : Number.POSITIVE_INFINITY
+        : (bench.avgNs - baseline.avgNs) / baseline.avgNs;
+    comparisons.push({
+      name: bench.name,
+      previousAvgNs: baseline.avgNs,
+      currentAvgNs: bench.avgNs,
+      changeRatio,
+    });
+  }
+
+  return {
+    comparisons,
+    failures: comparisons.filter((comparison) => comparison.changeRatio > threshold),
+    added,
+    missing: previous.benches
+      .filter((bench) => !currentNames.has(bench.name))
+      .map((bench) => bench.name),
+  };
+}

--- a/benchmarks/bench_trends_core_test.ts
+++ b/benchmarks/bench_trends_core_test.ts
@@ -1,0 +1,62 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  type BenchSnapshot,
+  compareBenchSnapshots,
+  parseRegressionThreshold,
+} from "./bench_trends_core.ts";
+
+function snapshot(benches: Record<string, number>): BenchSnapshot {
+  return {
+    timestamp: "2026-09-05T00:00:00.000Z",
+    benches: Object.entries(benches).map(([name, avgNs]) => ({ name, avgNs, p99Ns: avgNs })),
+  };
+}
+
+Deno.test("benchmark trends: identifies regressions beyond the threshold", () => {
+  const result = compareBenchSnapshots(
+    snapshot({ stable: 100, slower: 100, faster: 100 }),
+    snapshot({ stable: 110, slower: 121, faster: 80 }),
+    0.2,
+  );
+
+  assertEquals(
+    result.failures.map((entry) => entry.name),
+    ["slower"],
+  );
+  assertEquals(
+    result.comparisons.map((entry) => entry.changeRatio),
+    [0.1, 0.21, -0.2],
+  );
+});
+
+Deno.test("benchmark trends: reports added and missing scenarios", () => {
+  const result = compareBenchSnapshots(
+    snapshot({ retained: 100, removed: 100 }),
+    snapshot({ retained: 100, added: 100 }),
+  );
+
+  assertEquals(result.added, ["added"]);
+  assertEquals(result.missing, ["removed"]);
+});
+
+Deno.test("benchmark trends: handles a zero-duration baseline", () => {
+  const result = compareBenchSnapshots(
+    snapshot({ unchanged: 0, slower: 0 }),
+    snapshot({
+      unchanged: 0,
+      slower: 1,
+    }),
+  );
+
+  assertEquals(result.comparisons[0].changeRatio, 0);
+  assertEquals(result.comparisons[1].changeRatio, Number.POSITIVE_INFINITY);
+  assertEquals(result.failures.length, 1);
+});
+
+Deno.test("benchmark trends: validates the regression threshold", () => {
+  assertEquals(parseRegressionThreshold(undefined), 0.2);
+  assertEquals(parseRegressionThreshold("0"), 0);
+  assertEquals(parseRegressionThreshold("0.35"), 0.35);
+  assertThrows(() => parseRegressionThreshold("-0.1"), Error, "non-negative number");
+  assertThrows(() => parseRegressionThreshold("nope"), Error, "non-negative number");
+});

--- a/benchmarks/benchmark_report.ts
+++ b/benchmarks/benchmark_report.ts
@@ -110,11 +110,13 @@ ${table(microRows)}
 \`\`\`sh
 deno task bench:report
 deno task bench:check
+deno task bench:trends
 \`\`\`
 
 Run on an otherwise idle machine. The performance gate evaluates averages
 against committed budgets; this report additionally publishes sample count,
-minimum, p75, and p99 latency.
+minimum, p75, and p99 latency. The trends command compares a run with the
+last accepted local baseline and rejects average regressions above 20%.
 `;
 
 await Deno.writeTextFile(outputPath, report);

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -52,7 +52,11 @@ keeping transactional staging and promotion in place. Fixture creation happens o
 ```sh
 deno task bench:report
 deno task bench:check
+deno task bench:trends
 ```
 
 Run this on an otherwise idle machine. The performance gate checks averages against committed
 budgets; this report also publishes sample count, minimum, p75, and p99 latency for the curious.
+The trends command stores its local history under `benchmarks/.bench-history`, compares each run
+with the last accepted baseline, and exits unsuccessfully when an average regresses by more than
+20%. Set `STENO_BENCH_TREND_THRESHOLD` to a non-negative ratio to override that limit locally.


### PR DESCRIPTION
## Summary
- compare benchmark runs with the last accepted local baseline
- reject average regressions above a configurable 20% threshold
- preserve failed runs in history without promoting them to the baseline
- document the trend workflow

## Verification
- deno task check
- deno task bench:check
- two consecutive deno task bench:trends runs

Depends on #252.